### PR TITLE
Feat: [EVER-123] 공통 Alert 컴포넌트 구현 및 스타일 적용, Layout 좌우 여백 설정

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Alert } from '../ui/alert';
+
+const meta: Meta<typeof Alert> = {
+  title: 'Components/Alert',
+  component: Alert,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive'],
+    },
+    children: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Alert>;
+
+export const Playground: Story = {
+  args: {
+    variant: 'default',
+    children: 'Heads up! You can add components to your app using the CLI.',
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    variant: 'destructive',
+    children: 'Your session has expired. Please log in again.',
+  },
+};

--- a/src/components/Alert/Alert.types.ts
+++ b/src/components/Alert/Alert.types.ts
@@ -1,0 +1,9 @@
+import type { VariantProps } from 'class-variance-authority';
+import type { HTMLAttributes } from 'react';
+import { alertVariants } from './alertVariants';
+
+export interface AlertProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {
+  asChild?: boolean;
+}

--- a/src/components/Alert/alertVariants.ts
+++ b/src/components/Alert/alertVariants.ts
@@ -1,0 +1,13 @@
+import { cva } from 'class-variance-authority';
+
+export const alertVariants = cva('relative w-full rounded-lg border p-4 text-sm', {
+  variants: {
+    variant: {
+      default: 'bg-muted text-muted-foreground',
+      destructive: 'bg-red-50 text-red-700 border-red-500',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});

--- a/src/components/Alert/index.ts
+++ b/src/components/Alert/index.ts
@@ -1,0 +1,1 @@
+export * from '../ui/alert';

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -7,7 +7,7 @@ const Layout = (): React.ReactElement => {
     <section className="min-h-[100dvh] w-full bg-[var(--color-background)] text-[var(--color-foreground)]">
       <div className="mx-auto w-full max-w-[375px] min-h-[100dvh] flex flex-col relative">
         <TopNav />
-        <main className="flex-1 min-h-0 overflow-y-auto px-safe pt-safe pb-safe border border-gray-300/60">
+        <main className="flex-1 min-h-0 overflow-y-auto px-6 px-safe pt-safe pb-safe border border-gray-300/60">
           <Outlet />
         </main>
         <BottomNav />

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/lib/utils';
+import { ExclamationTriangleIcon, InfoCircledIcon } from '@radix-ui/react-icons';
+import { HTMLAttributes } from 'react';
+import type { VariantProps } from 'class-variance-authority';
+import { alertVariants } from '../Alert/alertVariants';
+
+interface AlertProps extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof alertVariants> {
+  title: string;
+  description?: string;
+}
+
+export function Alert({
+  title,
+  description,
+  variant = 'default',
+  className,
+  ...props
+}: AlertProps) {
+  const isDestructive = variant === 'destructive';
+
+  return (
+    <div className={cn(alertVariants({ variant }), className)} {...props}>
+      <div className="flex gap-2 items-start">
+        {isDestructive ? (
+          <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 text-red-500" />
+        ) : (
+          <InfoCircledIcon className="mt-0.5 h-5 w-5 text-muted-foreground" />
+        )}
+        <div>
+          <h4 className="font-semibold text-s">{title}</h4>
+          {description && <p className="text-xs mt-1">{description}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### #️⃣연관된 이슈

### 🔎 작업 내용

- [x] Alert 컴포넌트 생성 (ui/alert.tsx)
- [x] 아이콘, title, description 포함 구성
- [x] default, destructive variant 스타일 구현
- [x] 글꼴 크기 및 여백 디자인 적용
- [x] Storybook 테스트 작성
- [x] Layout에 px-6 적용되어 전체 페이지 일관된 여백 유지

### 📸 스크린샷
- storybook 테스트
<img width="529" alt="image" src="https://github.com/user-attachments/assets/b2470532-ac8e-474d-9e24-05d3a38c98da" />

- 실제 화면 테스트(테스트만 하고 다시 삭제함)
![image](https://github.com/user-attachments/assets/e9dd7454-c456-4ad4-a9e3-361d21a75f57)


### :loudspeaker: 전달사항
- Layout에 px-6 적용되어 전체 페이지 일관된 여백 유지 (좌우 24: 피그마 참고)

## ✅ Check List

- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
