### PR TITLE
Feat: [EVER-127] 공통 Skeleton 컴포넌트 구현

### DIFF
--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Skeleton } from '../ui/skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Components/Skeleton',
+  component: Skeleton,
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: 'text',
+      description: 'Tailwind classes to control size/shape',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  args: {
+    className: 'h-4 w-32',
+  },
+};
+
+export const Circle: Story = {
+  args: {
+    className: 'h-10 w-10 rounded-full',
+  },
+};
+
+export const LargeBlock: Story = {
+  args: {
+    className: 'h-20 w-full',
+  },
+};

--- a/src/components/Skeleton/Skeleton.types.ts
+++ b/src/components/Skeleton/Skeleton.types.ts
@@ -1,0 +1,5 @@
+import type { HTMLAttributes } from 'react';
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  asChild?: boolean;
+}

--- a/src/components/Skeleton/index.ts
+++ b/src/components/Skeleton/index.ts
@@ -1,0 +1,1 @@
+export * from '../ui/skeleton';

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,14 +1,9 @@
-import React from 'react';
 import { cn } from '@/lib/utils';
+import { Slot } from '@radix-ui/react-slot';
+import type { SkeletonProps } from '../Skeleton/Skeleton.types';
 
-function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="skeleton"
-      className={cn('bg-accent animate-pulse rounded-md', className)}
-      {...props}
-    />
-  );
+export function Skeleton({ className, asChild = false, ...props }: SkeletonProps) {
+  const Comp = asChild ? Slot : 'div';
+
+  return <Comp className={cn('animate-pulse rounded-md bg-gray-100', className)} {...props} />;
 }
-
-export { Skeleton };


### PR DESCRIPTION
### #️⃣연관된 이슈
> close: #31 
### 🔎 작업 내용

- [x] Skeleton 컴포넌트 구현 (ui/skeleton.tsx)
- [x] asChild, className 등 유연한 props 적용
- [x] 기본 스타일: animate-pulse, rounded, 배경색 진하게 조정
- [x] Skeleton.types.ts에서 타입 분리
- [x] Storybook 예시 3종 작성: 기본, 원형, 큰 블럭
- [x] index.ts에 export 추가

### 📸 스크린샷
-bg-muted 기본 버전
![image](https://github.com/user-attachments/assets/084dc069-6746-4ffe-a4c4-114e7796c97d)

-bg-gray-100 버전
![image](https://github.com/user-attachments/assets/6e98d670-8aee-4fa7-96fe-cb3bc069824c)

-bg-gray-200 버전
![image](https://github.com/user-attachments/assets/8eb04755-cbd7-4715-b347-75f8e25a71bd)


### :loudspeaker: 전달사항
- 추후 팀 디자인 토큰에 맞게 색상 통일 예정
- bg-muted이 shadcn 기본인데 storybook에서 테스트 했을 때 너무 연해서 **bg-muted vs bg-gray-100** 투표해주세요! 현재는  bg-gray-100으로 되어있어서 팀원들 의견 듣고 추후 수정하겠습니다.

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
