### PR TITLE
Feat: [EVER-128] 공통 Modal 컴포넌트 만들기 및 전역 스토어 등록

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "base-react",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-slot": "^1.2.3",
@@ -1266,6 +1267,42 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -1281,6 +1318,73 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
+      "integrity": "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
+      "integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-icons": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
@@ -1288,6 +1392,48 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-presence": {
@@ -1391,6 +1537,61 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
       "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -3189,6 +3390,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -4129,6 +4342,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -5562,6 +5781,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -8777,6 +9005,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
@@ -8813,6 +9088,28 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/recast": {
@@ -10073,7 +10370,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tw-animate-css": {
@@ -10380,6 +10676,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-slot": "^1.2.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from 'react-router-dom';
+import { GlobalModalProvider } from './provider/GlobalModalProvider/GlobalModalProvider';
 import router from './routes';
 
 const queryClient = new QueryClient();
@@ -8,6 +9,7 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <GlobalModalProvider />
     </QueryClientProvider>
   );
 }

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,0 +1,160 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '@/components/Button';
+import {
+  Modal,
+  ModalTrigger,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalDescription,
+  ModalFooter,
+} from './Modal';
+import type { VariantProps } from 'class-variance-authority';
+import { contentVariants } from './modalVariants';
+
+type ModalVariant = VariantProps<typeof contentVariants>['variant'];
+type ModalSize = VariantProps<typeof contentVariants>['size'];
+
+const meta: Meta<typeof Modal> = {
+  title: 'Components/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  argTypes: {
+    defaultOpen: {
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+interface PlaygroundArgs {
+  defaultOpen?: boolean;
+}
+
+export const Playground: Story = {
+  render: (args: PlaygroundArgs) => (
+    <Modal {...args}>
+      <ModalTrigger asChild>
+        <Button>Open Modal</Button>
+      </ModalTrigger>
+      <ModalContent variant="default" size="default">
+        <ModalHeader>
+          <ModalTitle>Modal Title</ModalTitle>
+          <ModalDescription>
+            This is a modal description. You can add any content here.
+          </ModalDescription>
+        </ModalHeader>
+        <div className="grid gap-4 py-4">
+          <p>Modal content goes here...</p>
+        </div>
+        <ModalFooter>
+          <Button variant="outline">Cancel</Button>
+          <Button>Save changes</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  ),
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-4">
+      {[
+        { variant: 'default', label: 'Default' },
+        { variant: 'minimal', label: 'Minimal' },
+        { variant: 'drawer', label: 'Drawer' },
+      ].map((item) => (
+        <Modal key={item.variant}>
+          <ModalTrigger asChild>
+            <Button variant="outline">{item.label}</Button>
+          </ModalTrigger>
+          <ModalContent variant={item.variant as ModalVariant}>
+            <ModalHeader>
+              <ModalTitle>{item.label} Modal</ModalTitle>
+              <ModalDescription>
+                This is a {item.label.toLowerCase()} variant modal.
+              </ModalDescription>
+            </ModalHeader>
+            <div className="py-4">
+              <p>Content for {item.label} modal...</p>
+            </div>
+            <ModalFooter>
+              <Button variant="outline">Cancel</Button>
+              <Button>Confirm</Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      ))}
+    </div>
+  ),
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-4">
+      {(['sm', 'default', 'lg', 'xl'] as ModalSize[]).map((size) => (
+        <Modal key={size}>
+          <ModalTrigger asChild>
+            <Button variant="outline">Size: {size}</Button>
+          </ModalTrigger>
+          <ModalContent size={size}>
+            <ModalHeader>
+              <ModalTitle>Size: {size}</ModalTitle>
+              <ModalDescription>This modal has size variant: {size}</ModalDescription>
+            </ModalHeader>
+            <div className="py-4">
+              <p>Content scales with the {size} size...</p>
+            </div>
+            <ModalFooter>
+              <Button>Close</Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      ))}
+    </div>
+  ),
+};
+
+export const FormModal: Story = {
+  render: () => (
+    <Modal>
+      <ModalTrigger asChild>
+        <Button>Create Account</Button>
+      </ModalTrigger>
+      <ModalContent variant="default" size="lg">
+        <ModalHeader>
+          <ModalTitle>Create your account</ModalTitle>
+          <ModalDescription>Enter your information to create a new account.</ModalDescription>
+        </ModalHeader>
+        <ModalFooter>
+          <Button variant="outline">Cancel</Button>
+          <Button>Create Account</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  ),
+};
+
+export const ConfirmationModal: Story = {
+  render: () => (
+    <Modal>
+      <ModalTrigger asChild>
+        <Button variant="destructive">Delete Item</Button>
+      </ModalTrigger>
+      <ModalContent variant="minimal" size="sm">
+        <ModalHeader>
+          <ModalTitle>Are you sure?</ModalTitle>
+          <ModalDescription>
+            This action cannot be undone. This will permanently delete the item.
+          </ModalDescription>
+        </ModalHeader>
+        <ModalFooter>
+          <Button variant="outline">Cancel</Button>
+          <Button variant="destructive">Delete</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  ),
+};

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -12,16 +12,24 @@ import {
 import type { VariantProps } from 'class-variance-authority';
 import { contentVariants } from './modalVariants';
 
-type ModalVariant = VariantProps<typeof contentVariants>['variant'];
 type ModalSize = VariantProps<typeof contentVariants>['size'];
 
 const meta: Meta<typeof Modal> = {
   title: 'Components/Modal',
   component: Modal,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '다양한 유형의 모달 컴포넌트입니다. 기본 모달, 확인 모달, 폼 모달 등 다양한 패턴을 지원합니다.',
+      },
+    },
+  },
   argTypes: {
     defaultOpen: {
       control: 'boolean',
+      description: '모달의 기본 열림 상태를 설정합니다.',
     },
   },
 };
@@ -34,6 +42,13 @@ interface PlaygroundArgs {
 }
 
 export const Playground: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 모달 예시입니다. X 버튼과 취소/저장 버튼이 모두 있는 일반적인 패턴입니다.',
+      },
+    },
+  },
   render: (args: PlaygroundArgs) => (
     <Modal {...args}>
       <ModalTrigger asChild>
@@ -41,14 +56,9 @@ export const Playground: Story = {
       </ModalTrigger>
       <ModalContent variant="default" size="default">
         <ModalHeader>
-          <ModalTitle>Modal Title</ModalTitle>
-          <ModalDescription>
-            This is a modal description. You can add any content here.
-          </ModalDescription>
+          <ModalTitle>Edit Profile</ModalTitle>
+          <ModalDescription>모달 설명을 여기다 적음</ModalDescription>
         </ModalHeader>
-        <div className="grid gap-4 py-4">
-          <p>Modal content goes here...</p>
-        </div>
         <ModalFooter>
           <Button variant="outline">Cancel</Button>
           <Button>Save changes</Button>
@@ -56,42 +66,115 @@ export const Playground: Story = {
       </ModalContent>
     </Modal>
   ),
+  args: {
+    defaultOpen: false,
+  },
 };
 
-export const AllVariants: Story = {
+export const ConfirmationModal: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '확인 모달입니다. 중요한 액션에 대한 확인을 받을 때 사용하며, X 버튼 없이 명시적인 선택만 가능합니다.',
+      },
+    },
+  },
   render: () => (
-    <div className="flex flex-wrap gap-4">
-      {[
-        { variant: 'default', label: 'Default' },
-        { variant: 'minimal', label: 'Minimal' },
-        { variant: 'drawer', label: 'Drawer' },
-      ].map((item) => (
-        <Modal key={item.variant}>
-          <ModalTrigger asChild>
-            <Button variant="outline">{item.label}</Button>
-          </ModalTrigger>
-          <ModalContent variant={item.variant as ModalVariant}>
-            <ModalHeader>
-              <ModalTitle>{item.label} Modal</ModalTitle>
-              <ModalDescription>
-                This is a {item.label.toLowerCase()} variant modal.
-              </ModalDescription>
-            </ModalHeader>
-            <div className="py-4">
-              <p>Content for {item.label} modal...</p>
-            </div>
-            <ModalFooter>
-              <Button variant="outline">Cancel</Button>
-              <Button>Confirm</Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-      ))}
-    </div>
+    <Modal>
+      <ModalTrigger asChild>
+        <Button variant="destructive">Delete Account</Button>
+      </ModalTrigger>
+      <ModalContent variant="default" size="sm" showClose={false}>
+        <ModalHeader>
+          <ModalTitle>Delete Account</ModalTitle>
+          <ModalDescription>
+            계정을 삭제하시겠습니까? 이 작업은 되돌릴 수 없으며 모든 데이터가 영구적으로 삭제됩니다.
+          </ModalDescription>
+        </ModalHeader>
+        <ModalFooter>
+          <Button variant="outline">Cancel</Button>
+          <Button variant="destructive">Delete Account</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  ),
+};
+
+export const AlertModal: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '알림 모달입니다. 정보 전달 목적으로 사용하며, X 버튼 없이 확인 버튼만 제공합니다.',
+      },
+    },
+  },
+  render: () => (
+    <Modal>
+      <ModalTrigger asChild>
+        <Button>Show Alert</Button>
+      </ModalTrigger>
+      <ModalContent variant="default" size="sm" showClose={false}>
+        <ModalHeader>
+          <ModalTitle>Success</ModalTitle>
+          <ModalDescription>
+            작업이 성공적으로 완료되었습니다. 이메일로 확인 메시지를 발송했습니다.
+          </ModalDescription>
+        </ModalHeader>
+        <ModalFooter>
+          <Button className="w-full">OK</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  ),
+};
+
+export const InformationModal: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '정보 표시 모달입니다. 내용을 읽고 X 버튼으로 닫을 수 있으며, 별도의 액션 버튼은 없습니다.',
+      },
+    },
+  },
+  render: () => (
+    <Modal>
+      <ModalTrigger asChild>
+        <Button variant="outline">View Terms</Button>
+      </ModalTrigger>
+      <ModalContent variant="default" size="lg">
+        <ModalHeader>
+          <ModalTitle>Terms of Service</ModalTitle>
+          <ModalDescription>
+            서비스 이용약관을 확인해주세요. 궁금한 점이 있으시면 고객센터로 문의하세요.
+          </ModalDescription>
+        </ModalHeader>
+        <div className="max-h-96 overflow-y-auto py-4">
+          <div className="space-y-4 text-sm">
+            <section>
+              <h3 className="font-semibold mb-2">1. Service Usage</h3>
+              <p>
+                This service is provided for legitimate business purposes only. Users must comply
+                with all applicable laws and regulations.
+              </p>
+            </section>
+          </div>
+        </div>
+        {/* X 버튼으로만 닫을 수 있는 모달 - 푸터 없음 */}
+      </ModalContent>
+    </Modal>
   ),
 };
 
 export const AllSizes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '다양한 크기의 모달을 보여줍니다. sm, default, lg, xl 크기를 지원합니다.',
+      },
+    },
+  },
   render: () => (
     <div className="flex flex-wrap gap-4">
       {(['sm', 'default', 'lg', 'xl'] as ModalSize[]).map((size) => (
@@ -101,11 +184,16 @@ export const AllSizes: Story = {
           </ModalTrigger>
           <ModalContent size={size}>
             <ModalHeader>
-              <ModalTitle>Size: {size}</ModalTitle>
-              <ModalDescription>This modal has size variant: {size}</ModalDescription>
+              <ModalTitle>Modal Size: {size}</ModalTitle>
+              <ModalDescription>
+                이 모달은 {size} 크기로 설정되어 있습니다. 콘텐츠에 따라 적절한 크기를 선택하세요.
+              </ModalDescription>
             </ModalHeader>
             <div className="py-4">
-              <p>Content scales with the {size} size...</p>
+              <p>
+                Content scales with the {size} size. This helps you choose the right size for your
+                content.
+              </p>
             </div>
             <ModalFooter>
               <Button>Close</Button>
@@ -114,47 +202,5 @@ export const AllSizes: Story = {
         </Modal>
       ))}
     </div>
-  ),
-};
-
-export const FormModal: Story = {
-  render: () => (
-    <Modal>
-      <ModalTrigger asChild>
-        <Button>Create Account</Button>
-      </ModalTrigger>
-      <ModalContent variant="default" size="lg">
-        <ModalHeader>
-          <ModalTitle>Create your account</ModalTitle>
-          <ModalDescription>Enter your information to create a new account.</ModalDescription>
-        </ModalHeader>
-        <ModalFooter>
-          <Button variant="outline">Cancel</Button>
-          <Button>Create Account</Button>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
-  ),
-};
-
-export const ConfirmationModal: Story = {
-  render: () => (
-    <Modal>
-      <ModalTrigger asChild>
-        <Button variant="destructive">Delete Item</Button>
-      </ModalTrigger>
-      <ModalContent variant="minimal" size="sm">
-        <ModalHeader>
-          <ModalTitle>Are you sure?</ModalTitle>
-          <ModalDescription>
-            This action cannot be undone. This will permanently delete the item.
-          </ModalDescription>
-        </ModalHeader>
-        <ModalFooter>
-          <Button variant="outline">Cancel</Button>
-          <Button variant="destructive">Delete</Button>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
   ),
 };

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -16,39 +16,49 @@ const ModalPortal = DialogPrimitive.Portal;
 
 const ModalOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & {
-    variant?: 'default' | 'blur';
-  }
->(({ className, variant = 'default', ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(overlayVariants({ variant, className }))}
-    {...props}
-  />
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay ref={ref} className={cn(overlayVariants({ className }))} {...props} />
 ));
 ModalOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const ModalContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   ModalContentProps
->(({ className, variant, size, children, showCloseButton = true, ...props }, ref) => (
-  <ModalPortal>
-    <ModalOverlay variant={variant === 'drawer' ? 'default' : 'blur'} />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(contentVariants({ variant, size, className }))}
-      {...props}
-    >
-      {children}
-      {showCloseButton && (
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      )}
-    </DialogPrimitive.Content>
-  </ModalPortal>
-));
+>(
+  (
+    {
+      className,
+      variant,
+      size,
+      children,
+      showClose = true,
+      closeOnOverlayClick = true,
+      closeOnEscape = true,
+      ...props
+    },
+    ref,
+  ) => (
+    <ModalPortal>
+      <ModalOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(contentVariants({ variant, size, className }))}
+        onPointerDownOutside={closeOnOverlayClick ? undefined : (e) => e.preventDefault()}
+        onEscapeKeyDown={closeOnEscape ? undefined : (e) => e.preventDefault()}
+        {...props}
+      >
+        {children}
+        {showClose && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+            <X className="h-4 w-4" />
+            <span className="sr-only">닫기</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </ModalPortal>
+  ),
+);
 ModalContent.displayName = DialogPrimitive.Content.displayName;
 
 const ModalHeader: React.FC<ModalHeaderProps> = ({ className, ...props }) => (
@@ -57,7 +67,7 @@ const ModalHeader: React.FC<ModalHeaderProps> = ({ className, ...props }) => (
 
 const ModalFooter: React.FC<ModalFooterProps> = ({ className, ...props }) => (
   <div
-    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-2', className)}
     {...props}
   />
 );

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { contentVariants, overlayVariants } from './modalVariants';
+import type {
+  ModalProps,
+  ModalContentProps,
+  ModalHeaderProps,
+  ModalFooterProps,
+} from './Modal.types';
+
+const ModalRoot = DialogPrimitive.Root;
+const ModalTrigger = DialogPrimitive.Trigger;
+const ModalPortal = DialogPrimitive.Portal;
+
+const ModalOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & {
+    variant?: 'default' | 'blur';
+  }
+>(({ className, variant = 'default', ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(overlayVariants({ variant, className }))}
+    {...props}
+  />
+));
+ModalOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const ModalContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  ModalContentProps
+>(({ className, variant, size, children, showCloseButton = true, ...props }, ref) => (
+  <ModalPortal>
+    <ModalOverlay variant={variant === 'drawer' ? 'default' : 'blur'} />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(contentVariants({ variant, size, className }))}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
+    </DialogPrimitive.Content>
+  </ModalPortal>
+));
+ModalContent.displayName = DialogPrimitive.Content.displayName;
+
+const ModalHeader: React.FC<ModalHeaderProps> = ({ className, ...props }) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+
+const ModalFooter: React.FC<ModalFooterProps> = ({ className, ...props }) => (
+  <div
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+);
+
+const ModalTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+ModalTitle.displayName = DialogPrimitive.Title.displayName;
+
+const ModalDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+ModalDescription.displayName = DialogPrimitive.Description.displayName;
+
+export function Modal({ children, ...props }: ModalProps) {
+  return <ModalRoot {...props}>{children}</ModalRoot>;
+}
+
+export {
+  ModalRoot,
+  ModalTrigger,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalTitle,
+  ModalDescription,
+  ModalOverlay,
+  ModalPortal,
+};

--- a/src/components/Modal/Modal.types.ts
+++ b/src/components/Modal/Modal.types.ts
@@ -8,9 +8,10 @@ export interface ModalProps extends React.ComponentProps<typeof DialogPrimitive.
 export interface ModalContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
     VariantProps<typeof contentVariants> {
-  showCloseButton?: boolean;
+  showClose?: boolean;
+  closeOnOverlayClick?: boolean;
+  closeOnEscape?: boolean;
 }
 
 export interface ModalHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
-
 export interface ModalFooterProps extends React.HTMLAttributes<HTMLDivElement> {}

--- a/src/components/Modal/Modal.types.ts
+++ b/src/components/Modal/Modal.types.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { VariantProps } from 'class-variance-authority';
+import { contentVariants } from './modalVariants';
+
+export interface ModalProps extends React.ComponentProps<typeof DialogPrimitive.Root> {}
+
+export interface ModalContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
+    VariantProps<typeof contentVariants> {
+  showCloseButton?: boolean;
+}
+
+export interface ModalHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export interface ModalFooterProps extends React.HTMLAttributes<HTMLDivElement> {}

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,0 +1,3 @@
+export * from './Modal';
+export * from './Modal.types';
+export * from './modalVariants';

--- a/src/components/Modal/modalVariants.ts
+++ b/src/components/Modal/modalVariants.ts
@@ -1,0 +1,61 @@
+import { cva } from 'class-variance-authority';
+
+export const overlayVariants = cva('fixed inset-0 z-50 transition-all duration-200', {
+  variants: {
+    variant: {
+      default: 'bg-black/50',
+      blur: 'bg-black/50 backdrop-blur-sm',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export const contentVariants = cva(
+  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+  {
+    variants: {
+      variant: {
+        default: 'rounded-lg',
+        minimal: 'rounded-lg border-0 shadow-2xl',
+        drawer:
+          'fixed inset-x-0 bottom-0 top-auto translate-x-0 translate-y-0 rounded-t-lg data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        fullscreen: 'h-screen w-screen rounded-none',
+      },
+      size: {
+        sm: 'max-w-sm',
+        default: 'max-w-lg',
+        lg: 'max-w-2xl',
+        xl: 'max-w-4xl',
+        auto: 'w-auto',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export const modalVariants = cva('', {
+  variants: {
+    variant: {
+      default: '',
+      minimal: '',
+      drawer: '',
+      fullscreen: '',
+    },
+    size: {
+      sm: '',
+      default: '',
+      lg: '',
+      xl: '',
+      auto: '',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'default',
+  },
+});

--- a/src/components/Modal/modalVariants.ts
+++ b/src/components/Modal/modalVariants.ts
@@ -1,19 +1,16 @@
 import { cva } from 'class-variance-authority';
 
-export const overlayVariants = cva('fixed inset-0 z-50 transition-all duration-200', {
+export const overlayVariants = cva('fixed inset-0 z-50 bg-black/50 backdrop-blur-sm', {
   variants: {
     variant: {
-      default: 'bg-black/50',
-      blur: 'bg-black/50 backdrop-blur-sm',
+      default: '',
+      blur: 'backdrop-blur-md',
     },
-  },
-  defaultVariants: {
-    variant: 'default',
   },
 });
 
 export const contentVariants = cva(
-  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
   {
     variants: {
       variant: {
@@ -21,14 +18,13 @@ export const contentVariants = cva(
         minimal: 'rounded-lg border-0 shadow-2xl',
         drawer:
           'fixed inset-x-0 bottom-0 top-auto translate-x-0 translate-y-0 rounded-t-lg data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
-        fullscreen: 'h-screen w-screen rounded-none',
+        alert: 'rounded-lg shadow-xl',
       },
       size: {
         sm: 'max-w-sm',
         default: 'max-w-lg',
         lg: 'max-w-2xl',
         xl: 'max-w-4xl',
-        auto: 'w-auto',
       },
     },
     defaultVariants: {
@@ -37,25 +33,3 @@ export const contentVariants = cva(
     },
   },
 );
-
-export const modalVariants = cva('', {
-  variants: {
-    variant: {
-      default: '',
-      minimal: '',
-      drawer: '',
-      fullscreen: '',
-    },
-    size: {
-      sm: '',
-      default: '',
-      lg: '',
-      xl: '',
-      auto: '',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-    size: 'default',
-  },
-});

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,108 @@
+import { useModalStore, ModalConfig } from '@/stores/useModalStore';
+import { useCallback } from 'react';
+
+export const useModal = () => {
+  const { openModal, closeModal, closeAllModals } = useModalStore();
+
+  const showModal = useCallback(
+    (config: Omit<ModalConfig, 'id'> & { id?: string }) => {
+      const modalId = config.id || `modal-${Date.now()}`;
+      openModal({ ...config, id: modalId });
+      return modalId;
+    },
+    [openModal],
+  );
+
+  const confirm = useCallback(
+    (title: string, description?: string, onConfirm?: () => void) => {
+      return showModal({
+        title,
+        description,
+        variant: 'alert',
+        size: 'sm',
+        confirmText: '확인',
+        cancelText: '취소',
+        onConfirm,
+      });
+    },
+    [showModal],
+  );
+
+  const alert = useCallback(
+    (title: string, description?: string, onConfirm?: () => void) => {
+      return showModal({
+        title,
+        description,
+        variant: 'alert',
+        size: 'sm',
+        showCancel: false,
+        confirmText: '확인',
+        onConfirm,
+      });
+    },
+    [showModal],
+  );
+
+  const prompt = useCallback(
+    (
+      title: string,
+      description?: string,
+      placeholder?: string,
+      onConfirm?: (value: string) => void,
+    ) => {
+      return showModal({
+        title,
+        description,
+        variant: 'default',
+        size: 'sm',
+        confirmText: '확인',
+        cancelText: '취소',
+        showInput: true,
+        inputPlaceholder: placeholder || '값을 입력하세요',
+        onConfirm: (value) => onConfirm?.(value || ''),
+      });
+    },
+    [showModal],
+  );
+
+  const success = useCallback(
+    (title: string, description?: string, onConfirm?: () => void) => {
+      return showModal({
+        title,
+        description,
+        variant: 'minimal',
+        size: 'sm',
+        showCancel: false,
+        confirmText: '확인',
+        onConfirm,
+      });
+    },
+    [showModal],
+  );
+
+  const error = useCallback(
+    (title: string, description?: string, onConfirm?: () => void) => {
+      return showModal({
+        title,
+        description,
+        variant: 'alert',
+        size: 'sm',
+        showCancel: false,
+        confirmText: '확인',
+        onConfirm,
+      });
+    },
+    [showModal],
+  );
+
+  return {
+    showModal,
+    closeModal,
+    closeAllModals,
+    confirm,
+    alert,
+    prompt,
+    success,
+    error,
+  };
+};

--- a/src/provider/GlobalModalProvider/GlobalModalProvider.tsx
+++ b/src/provider/GlobalModalProvider/GlobalModalProvider.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { useModalStore, ModalConfig } from '@/stores/useModalStore';
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalDescription,
+  ModalFooter,
+} from '@/components/Modal';
+import { Button } from '@/components/Button';
+
+export const GlobalModalProvider: React.FC = () => {
+  const { modals, closeModal } = useModalStore();
+  const [inputValues, setInputValues] = useState<Record<string, string>>({});
+
+  const handleInputChange = (modalId: string, value: string) => {
+    setInputValues((prev) => ({ ...prev, [modalId]: value }));
+  };
+
+  const handleConfirm = (modal: ModalConfig) => {
+    const inputValue = inputValues[modal.id] || '';
+    modal.onConfirm?.(modal.showInput ? inputValue : undefined);
+    closeModal(modal.id);
+    // 입력값 정리
+    setInputValues((prev) => {
+      const newValues = { ...prev };
+      delete newValues[modal.id];
+      return newValues;
+    });
+  };
+
+  const handleCancel = (modal: ModalConfig) => {
+    modal.onCancel?.();
+    closeModal(modal.id);
+    // 입력값 정리
+    setInputValues((prev) => {
+      const newValues = { ...prev };
+      delete newValues[modal.id];
+      return newValues;
+    });
+  };
+
+  return (
+    <>
+      {modals.map((modal) => (
+        <Modal
+          key={modal.id}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) {
+              closeModal(modal.id);
+            }
+          }}
+        >
+          <ModalContent
+            variant={modal.variant || 'default'}
+            size={modal.size || 'default'}
+            showClose={modal.showClose ?? true}
+            closeOnOverlayClick={modal.closeOnOverlayClick ?? true}
+            closeOnEscape={modal.closeOnEscape ?? true}
+          >
+            {(modal.title || modal.description) && (
+              <ModalHeader>
+                {modal.title && <ModalTitle>{modal.title}</ModalTitle>}
+                {modal.description && <ModalDescription>{modal.description}</ModalDescription>}
+              </ModalHeader>
+            )}
+
+            {/* 커스텀 콘텐츠 */}
+            {modal.content && <div className="py-4">{modal.content}</div>}
+
+            {/* 입력 필드 */}
+            {modal.showInput && (
+              <div className="py-4">
+                <input
+                  type="text"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder={modal.inputPlaceholder || '값을 입력하세요'}
+                  value={inputValues[modal.id] || ''}
+                  onChange={(e) => handleInputChange(modal.id, e.target.value)}
+                  autoFocus
+                />
+              </div>
+            )}
+
+            {/* 푸터 버튼들 */}
+            {(modal.showCancel !== false || modal.showConfirm !== false) && (
+              <ModalFooter>
+                {modal.showCancel !== false && (
+                  <Button variant="outline" onClick={() => handleCancel(modal)}>
+                    {modal.cancelText || '취소'}
+                  </Button>
+                )}
+                {modal.showConfirm !== false && (
+                  <Button
+                    variant={modal.confirmVariant || 'default'}
+                    onClick={() => handleConfirm(modal)}
+                  >
+                    {modal.confirmText || '확인'}
+                  </Button>
+                )}
+              </ModalFooter>
+            )}
+          </ModalContent>
+        </Modal>
+      ))}
+    </>
+  );
+};

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,0 +1,57 @@
+import { create } from 'zustand';
+import { ReactNode } from 'react';
+
+export interface ModalConfig {
+  id: string;
+  title?: string;
+  description?: string;
+  content?: ReactNode;
+  variant?: 'default' | 'minimal' | 'drawer' | 'alert';
+  size?: 'sm' | 'default' | 'lg' | 'xl';
+  showClose?: boolean; // showCloseButton → showClose로 통일
+  showCancel?: boolean; // showCancelButton → showCancel로 변경
+  showConfirm?: boolean; // showConfirmButton → showConfirm로 변경
+  showInput?: boolean; // 입력 필드 표시 여부
+  inputPlaceholder?: string; // 입력 필드 플레이스홀더
+  cancelText?: string; // cancelButtonText → cancelText로 변경
+  confirmText?: string; // confirmButtonText → confirmText로 변경
+  confirmVariant?: 'default' | 'destructive' | 'outline' | 'secondary'; // confirmButtonVariant → confirmVariant로 변경
+  onCancel?: () => void;
+  onConfirm?: (value?: string) => void; // 입력값을 받을 수 있도록 수정
+  closeOnOverlayClick?: boolean;
+  closeOnEscape?: boolean;
+}
+
+interface ModalStore {
+  modals: ModalConfig[];
+  openModal: (config: ModalConfig) => void;
+  closeModal: (id: string) => void;
+  closeAllModals: () => void;
+  updateModal: (id: string, updates: Partial<ModalConfig>) => void;
+}
+
+export const useModalStore = create<ModalStore>((set) => ({
+  modals: [],
+
+  openModal: (config) => {
+    set((state) => ({
+      modals: [...state.modals.filter((m) => m.id !== config.id), config],
+    }));
+  },
+
+  closeModal: (id) => {
+    set((state) => ({
+      modals: state.modals.filter((m) => m.id !== id),
+    }));
+  },
+
+  closeAllModals: () => {
+    set({ modals: [] });
+  },
+
+  updateModal: (id, updates) => {
+    set((state) => ({
+      modals: state.modals.map((modal) => (modal.id === id ? { ...modal, ...updates } : modal)),
+    }));
+  },
+}));

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -113,3 +113,144 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* 모달 애니메이션을 위한 CSS */
+@layer base {
+  /* 애니메이션 키프레임 */
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes fadeOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+
+  @keyframes zoomIn {
+    from {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1);
+    }
+  }
+
+  @keyframes zoomOut {
+    from {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.95);
+    }
+  }
+
+  @keyframes slideInFromBottom {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes slideOutToBottom {
+    from {
+      transform: translateY(0);
+    }
+    to {
+      transform: translateY(100%);
+    }
+  }
+
+  /* 애니메이션 클래스 */
+  .animate-in {
+    animation-duration: 200ms;
+    animation-fill-mode: forwards;
+  }
+
+  .animate-out {
+    animation-duration: 200ms;
+    animation-fill-mode: forwards;
+  }
+
+  .fade-in-0 {
+    animation-name: fadeIn;
+  }
+
+  .fade-out-0 {
+    animation-name: fadeOut;
+  }
+
+  .zoom-in-95 {
+    animation-name: zoomIn;
+  }
+
+  .zoom-out-95 {
+    animation-name: zoomOut;
+  }
+
+  .slide-in-from-bottom {
+    animation-name: slideInFromBottom;
+  }
+
+  .slide-out-to-bottom {
+    animation-name: slideOutToBottom;
+  }
+
+  /* 데이터 상태에 따른 애니메이션 */
+  [data-state='open'] {
+    animation-duration: 200ms;
+    animation-timing-function: ease-out;
+  }
+
+  [data-state='closed'] {
+    animation-duration: 150ms;
+    animation-timing-function: ease-in;
+  }
+}
+
+@layer utilities {
+  /* 백드롭 필터 지원 */
+  .backdrop-blur-sm {
+    backdrop-filter: blur(4px);
+  }
+
+  .backdrop-blur-md {
+    backdrop-filter: blur(12px);
+  }
+
+  /* 링 스타일 */
+  .ring-offset-background {
+    --tw-ring-offset-color: hsl(var(--background));
+  }
+
+  .ring-ring {
+    --tw-ring-color: hsl(var(--ring));
+  }
+
+  /* 포커스 링 */
+  .focus\:ring-2:focus {
+    --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width)
+      var(--tw-ring-offset-color);
+    --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width))
+      var(--tw-ring-color);
+    box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  }
+
+  .focus\:ring-offset-2:focus {
+    --tw-ring-offset-width: 2px;
+  }
+}


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #34 

### 🔎 작업 내용

- [x] **Zustand 기반 전역 상태 관리**
  -  컴포넌트 트리 깊이에 상관없이 어디서든 모달 호출 가능
  -  비동기 작업 후 모달 표시: API 호출 완료 후 성공/실패 모달을 간편하게 표시
  -  GlobalModalProvider 컴포넌트로 전역 모달들을 App 레벨에서 렌더링
- [x] useModal 커스텀 훅 개발
   - `confirm(title, description, onConfirm)`: 해지, 로그아웃 등 중요한 액션 확인용
     - 확인 모달: X버튼 숨김 → 사용자가 반드시 '취소' 또는 '확인' 선택하도록 강제
   - `alert(title, description)`: 단순 알림용
     - 알림 모달: X버튼 숨김 → '확인' 버튼으로만 닫기 가능
- [x]  Storybook 예시 및 문서화 완료

### 📸 스크린샷
<img width="850" alt="스크린샷 2025-06-12 오전 1 48 47" src="https://github.com/user-attachments/assets/cd37316e-98c2-4c06-9058-9e7a3af02237" />
<img width="497" alt="스크린샷 2025-06-12 오전 1 49 07" src="https://github.com/user-attachments/assets/3e600dd5-cd7b-4175-a0a7-2768fc593050" />
<img width="497" alt="스크린샷 2025-06-12 오전 1 49 20" src="https://github.com/user-attachments/assets/e4896eaf-1475-4bd9-81cf-7942056ad11f" />


### :loudspeaker: 전달사항
**전역 상태 사용 이유?**
- props drilling 없이 깊은 컴포넌트에서도 모달 호출 가능
여러 모달이 동시에 열려도 상태 충돌 없이 관리 가능하게 했습니당

- 추가한 라이브러리나 특이 사항
  - 새 라이브러리: @radix-ui/react-dialog, class-variance-authority 추가
## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
