### PR TITLE
Feat: [EVER-171] Banner 컴포넌트 구현

### DIFF
--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Banner } from './Banner';
+import { Button } from '../Button/Button';
+import { bannerVariants } from './bannerVariants';
+import type { VariantProps } from 'class-variance-authority';
+
+type BannerVariant = VariantProps<typeof bannerVariants>['variant'];
+type BannerSize = VariantProps<typeof bannerVariants>['size'];
+
+const meta: Meta<typeof Banner> = {
+  title: 'Components/Banner',
+  component: Banner,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'red', 'yellow', 'white', 'moonuz', 'gradient'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'default', 'lg'],
+    },
+    layout: {
+      control: 'select',
+      options: ['default', 'centered', 'split'],
+    },
+    title: { control: 'text' },
+    description: { control: 'text' },
+    image: { control: 'text' },
+    imageAlt: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Banner>;
+
+export const Playground: Story = {
+  args: {
+    title: '🐙 무너와 함께하는 스마트한 혜택!',
+    description: 'MZ세대를 위한 맞춤형 요금제와 구독 서비스를 AI로 추천받아보세요!',
+    variant: 'primary',
+    size: 'default',
+    layout: 'default',
+    image: 'https://avatars.githubusercontent.com/u/212847508?s=200&v=4',
+    actionButton: (
+      <Button
+        variant="outline"
+        size="default"
+        className="bg-white/20 border-white/30 text-white hover:bg-white/30"
+      >
+        자세히 보기
+      </Button>
+    ),
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="space-y-4">
+      {(['sm', 'default', 'lg'] as BannerSize[]).map((size) => (
+        <Banner
+          key={size}
+          size={size}
+          variant="moonuz"
+          title={`${size} 사이즈 배너`}
+          description="사이즈별 배너 미리보기입니다."
+          image="https://avatars.githubusercontent.com/u/212847508?s=200&v=4"
+        />
+      ))}
+    </div>
+  ),
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="space-y-4">
+      {(['primary', 'red', 'yellow', 'white', 'moonuz', 'gradient'] as BannerVariant[]).map(
+        (variant) => (
+          <Banner
+            key={variant}
+            variant={variant}
+            title={`${variant} 배너`}
+            description="브랜드 토큰을 활용한 배너 디자인입니다."
+            image="https://avatars.githubusercontent.com/u/212847508?s=200&v=4"
+          />
+        ),
+      )}
+    </div>
+  ),
+};

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,0 +1,95 @@
+import { cn } from '@/lib/utils';
+import { bannerVariants } from './bannerVariants';
+import type { BannerProps } from './Banner.types';
+
+export function Banner({
+  className,
+  variant,
+  size,
+  layout,
+  title,
+  description,
+  image,
+  imageAlt,
+  actionButton,
+  onClick,
+  ...props
+}: BannerProps) {
+  return (
+    <div
+      className={cn(bannerVariants({ variant, size, layout, className }))}
+      onClick={onClick}
+      {...props}
+    >
+      <div className="absolute inset-0 bg-black/10 pointer-events-none dark:bg-black/20" />
+      {image && (
+        <div
+          className={cn(
+            'relative z-10 flex-shrink-0',
+            layout === 'split' ? 'order-2 md:order-1' : 'mr-6',
+            layout === 'centered' && 'mb-4 mr-0',
+          )}
+        >
+          <img
+            src={image}
+            alt={imageAlt || title}
+            className={cn(
+              'object-cover rounded-lg shadow-md',
+              layout === 'split'
+                ? 'w-full h-32 md:h-40'
+                : layout === 'centered'
+                  ? 'w-20 h-20 md:w-24 md:h-24 mx-auto'
+                  : 'w-16 h-16 md:w-20 md:h-20',
+            )}
+          />
+        </div>
+      )}
+      <div
+        className={cn(
+          'relative z-10 flex-1 min-w-0',
+          layout === 'split' ? 'order-1 md:order-2' : '',
+          layout === 'centered' ? 'text-center' : '',
+        )}
+      >
+        <h2
+          className={cn(
+            'font-bold leading-tight mb-2 tracking-tight',
+            size === 'sm'
+              ? 'text-lg'
+              : size === 'lg'
+                ? 'text-2xl md:text-3xl'
+                : 'text-xl md:text-2xl',
+            'drop-shadow-sm',
+          )}
+        >
+          {title}
+        </h2>
+
+        {description && (
+          <p
+            className={cn(
+              'opacity-90 leading-relaxed mb-4 last:mb-0',
+              size === 'sm'
+                ? 'text-sm'
+                : size === 'lg'
+                  ? 'text-base md:text-lg'
+                  : 'text-sm md:text-base',
+              'drop-shadow-sm',
+            )}
+          >
+            {description}
+          </p>
+        )}
+        {actionButton && (
+          <div className={cn('mt-4', layout === 'centered' ? 'flex justify-center' : '')}>
+            {actionButton}
+          </div>
+        )}
+      </div>
+      {/* 동그라미 추가 */}
+      <div className="absolute top-0 right-0 w-32 h-32 bg-white/20 rounded-full -translate-y-16 translate-x-16 pointer-events-none dark:bg-white/10" />
+      <div className="absolute bottom-0 left-0 w-24 h-24 bg-white/15 rounded-full translate-y-12 -translate-x-12 pointer-events-none dark:bg-white/8" />
+      <div className="absolute top-1/2 right-8 w-16 h-16 bg-[var(--color-brand-darkblue-light)]/5 rounded-full pointer-events-none dark:bg-[var(--color-brand-yellow)]/20" />
+    </div>
+  );
+}

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -1,0 +1,14 @@
+import React from 'react';
+import { VariantProps } from 'class-variance-authority';
+import { bannerVariants } from './bannerVariants';
+
+export interface BannerProps
+  extends React.ComponentProps<'div'>,
+    VariantProps<typeof bannerVariants> {
+  title: string;
+  description?: string;
+  image?: string;
+  imageAlt?: string;
+  actionButton?: React.ReactNode;
+  onClick?: () => void;
+}

--- a/src/components/Banner/bannerVariants.ts
+++ b/src/components/Banner/bannerVariants.ts
@@ -1,0 +1,37 @@
+import { cva } from 'class-variance-authority';
+
+export const bannerVariants = cva(
+  'relative overflow-hidden rounded-lg cursor-pointer transition-all duration-300 hover:scale-[1.02] hover:shadow-lg',
+  {
+    variants: {
+      variant: {
+        primary:
+          'bg-[var(--color-brand-darkblue)] hover:bg-[var(--color-brand-darkblue-hover)] text-white dark:bg-[var(--color-brand-darkblue-hover)] dark:hover:bg-[var(--color-brand-darkblue)]',
+        white:
+          'bg-white text-gray-900 border border-gray-200 hover:bg-gray-50 dark:bg-gray-900 dark:text-white dark:border-gray-700 dark:hover:bg-gray-800',
+        red: 'bg-[var(--color-brand-red)] hover:bg-[var(--color-brand-red-hover)] text-white',
+        yellow:
+          'bg-[var(--color-brand-yellow)] hover:bg-[var(--color-brand-yellow-hover)] text-gray-900',
+        moonuz:
+          'bg-gradient-to-r from-[var(--color-brand-darkblue)] via-purple-600 to-[var(--color-brand-red)] text-white hover:from-[var(--color-brand-darkblue-hover)] hover:to-[var(--color-brand-red-hover)]',
+        gradient:
+          'bg-gradient-to-br from-[var(--color-brand-darkblue)] to-[var(--color-brand-red)] text-white hover:from-[var(--color-brand-darkblue-hover)] hover:to-[var(--color-brand-red-hover)]',
+      },
+      size: {
+        sm: 'p-4 min-h-[80px]',
+        default: 'p-6 min-h-[120px]',
+        lg: 'p-8 min-h-[180px]',
+      },
+      layout: {
+        default: 'flex items-center',
+        centered: 'flex items-center justify-center text-center',
+        split: 'grid grid-cols-1 md:grid-cols-2 items-center gap-6',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'default',
+      layout: 'default',
+    },
+  },
+);

--- a/src/components/Banner/index.ts
+++ b/src/components/Banner/index.ts
@@ -1,0 +1,3 @@
+export * from './Banner';
+export * from './Banner.types';
+export * from './bannerVariants';


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #64 

### 🔎 작업 내용

- [x] **Banner 컴포넌트 구현 및 스토리북 작성**
  - **6가지 variant 색상**: primary, red, yellow, white, moonuz, gradient -> 모두 다크모두 지원!
  - 레이아웃: default, centered, split
  - 사이즈: sm, default, lg
  - **props**: title, description, image...

### 📸 스크린샷
> 디폴트 배너
![스크린샷 2025-06-15 오후 5 05 33](https://github.com/user-attachments/assets/3b0bfbbe-b0fc-4673-a64a-ed777d0de0f3)

> 색상 종류
![스크린샷 2025-06-15 오후 5 06 12](https://github.com/user-attachments/assets/ac6c4aff-75bb-4bed-9339-da0f7a7e4a46)

### :loudspeaker: 전달사항
색상 더 필요하면 variant 추가하셔도 됩니당~
- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
