### PR TITLE
Feature/ever 158 common bill summary card

### DIFF
--- a/src/apis/plan/getCurrentPlan.ts
+++ b/src/apis/plan/getCurrentPlan.ts
@@ -1,7 +1,19 @@
 import { apiWithToken } from '@/lib/api/apiconfig';
 
 export const fetchCurrentPlan = async () => {
-  const res = await apiWithToken.get('/user/plan');
-  console.log('✅ 요금제 전체 응답:', res.data); // 🔍 전체 구조 확인
-  return res.data.data;
+  try {
+    const res = await apiWithToken.get('/user/plans', {
+      withCredentials: true,
+    });
+
+    return res.data.data;
+  } catch (error: any) {
+    if (error.response?.status === 401) {
+      console.error('인증 실패: ACCESS_TOKEN이 없거나 만료됨');
+      throw new Error('인증되지 않았습니다.');
+    }
+
+    console.error('요금제 조회 실패:', error);
+    throw new Error('요금제 조회 중 오류 발생');
+  }
 };

--- a/src/apis/plan/getCurrentPlan.ts
+++ b/src/apis/plan/getCurrentPlan.ts
@@ -1,4 +1,5 @@
 import { apiWithToken } from '@/lib/api/apiconfig';
+import axios from 'axios';
 
 export const fetchCurrentPlan = async () => {
   try {
@@ -7,13 +8,11 @@ export const fetchCurrentPlan = async () => {
     });
 
     return res.data.data;
-  } catch (error: any) {
-    if (error.response?.status === 401) {
-      console.error('인증 실패: ACCESS_TOKEN이 없거나 만료됨');
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
       throw new Error('인증되지 않았습니다.');
     }
 
-    console.error('요금제 조회 실패:', error);
     throw new Error('요금제 조회 중 오류 발생');
   }
 };

--- a/src/apis/plan/getCurrentPlan.ts
+++ b/src/apis/plan/getCurrentPlan.ts
@@ -1,0 +1,7 @@
+import { apiWithToken } from '@/lib/api/apiconfig';
+
+export const fetchCurrentPlan = async () => {
+  const res = await apiWithToken.get('/user/plan');
+  console.log('✅ 요금제 전체 응답:', res.data); // 🔍 전체 구조 확인
+  return res.data.data;
+};

--- a/src/components/BillSummaryCard/BillSummaryCard.tsx
+++ b/src/components/BillSummaryCard/BillSummaryCard.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import { ChevronDownIcon, ChevronUpIcon } from '@radix-ui/react-icons';
+import { Progress } from '@/components/Progress/Progress';
+import { BillSummaryCardProps } from './BillSummaryCard.types';
+import { formatPrice } from './BillSummaryCard.utils';
+
+const BillSummaryCard = ({
+  phoneNumber,
+  planName,
+  month,
+  amount,
+  usageData,
+  isExpanded: controlledExpanded,
+  onToggle,
+}: BillSummaryCardProps) => {
+  const [internalExpanded, setInternalExpanded] = useState(false);
+  const expanded = controlledExpanded ?? internalExpanded;
+
+  const handleToggle = () => {
+    if (onToggle) onToggle();
+    else setInternalExpanded(!expanded);
+  };
+
+  return (
+    <div className="w-full rounded-xl border p-4 shadow-sm bg-white">
+      <div className="flex justify-between items-center mb-1">
+        <p className="title-2">{phoneNumber}</p>
+        <button onClick={handleToggle} className="text-gray-500 hover:text-black transition">
+          {expanded ? (
+            <ChevronUpIcon className="w-4 h-4" />
+          ) : (
+            <ChevronDownIcon className="w-4 h-4" />
+          )}
+        </button>
+      </div>
+      <p className="caption-1 text-gray-400 mb-3">{planName}</p>
+      <hr className="border-t border-gray-200 my-3" />
+      <p className="body-1 mb-0">{month} 청구요금</p>
+      <div className="flex justify-between items-center mt-1">
+        <p className="caption-1 text-gray-400">납부 완료</p>
+        <p className="title-1 text-[var(--color-brand-darkblue)] text-right">
+          {formatPrice(amount)}
+        </p>
+      </div>
+      {expanded && usageData && (
+        <div className="mt-4 space-y-4">
+          {usageData.map((item, idx) => (
+            <div key={idx} className="space-y-2">
+              <div className="flex justify-between caption-1 text-gray-700">
+                <span>{item.label}</span>
+                <span>
+                  {item.current} / {item.total}
+                </span>
+              </div>
+              <Progress
+                variant={item.variant}
+                current={item.current}
+                total={item.total}
+                showFraction={false}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BillSummaryCard;

--- a/src/components/BillSummaryCard/BillSummaryCard.types.ts
+++ b/src/components/BillSummaryCard/BillSummaryCard.types.ts
@@ -1,0 +1,18 @@
+export type UsageVariant = 'data' | 'call' | 'video' | 'sms';
+
+export interface UsageData {
+  label: string;
+  variant: UsageVariant;
+  current: number;
+  total: number;
+}
+
+export interface BillSummaryCardProps {
+  phoneNumber: string;
+  planName: string;
+  month: string;
+  amount: number;
+  isExpanded?: boolean;
+  usageData?: UsageData[];
+  onToggle?: () => void;
+}

--- a/src/components/BillSummaryCard/BillSummaryCard.utils.ts
+++ b/src/components/BillSummaryCard/BillSummaryCard.utils.ts
@@ -1,0 +1,3 @@
+export const formatPrice = (price: number): string => {
+  return price.toLocaleString('ko-KR') + '원';
+};

--- a/src/components/BillSummaryCard/index.ts
+++ b/src/components/BillSummaryCard/index.ts
@@ -1,0 +1,1 @@
+export { default as BillSummaryCard } from './BillSummaryCard';

--- a/src/components/ui/billsummarycard.tsx
+++ b/src/components/ui/billsummarycard.tsx
@@ -1,0 +1,1 @@
+export { BillSummaryCard } from '../BillSummaryCard';

--- a/src/pages/me/MyPage.tsx
+++ b/src/pages/me/MyPage.tsx
@@ -1,17 +1,48 @@
+import { BillSummaryCard } from '@/components/ui/billsummarycard';
 import React from 'react';
-import { Outlet, Link } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { fetchCurrentPlan } from '@/apis/plan/getCurrentPlan';
 
 const MyPage: React.FC = () => {
+  const {
+    data: plan,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['currentPlan'],
+    queryFn: fetchCurrentPlan,
+  });
+
+  const month = `${new Date().getMonth() + 1}월`;
+
+  if (isLoading) return <p className="p-4">로딩 중...</p>;
+  if (error || !plan) return <p className="p-4">요금제를 불러오지 못했습니다.</p>;
+
   return (
-    <div>
-      <h1>마이페이지</h1>
-      <nav>
-        <Link to="coupons">쿠폰</Link> |<Link to="likes">좋아요</Link> |
-        <Link to="events">이벤트</Link> |<Link to="change-plans">요금제 변경</Link>
-      </nav>
+    <div className="p-4">
+      <BillSummaryCard
+        phoneNumber="010-1**4-5**8"
+        planName={plan.name}
+        month={month}
+        amount={Number(plan.price)}
+        usageData={[
+          { label: '데이터', variant: 'data', current: 6, total: 6 },
+          { label: '통화', variant: 'call', current: 1, total: 1 },
+          { label: '영상', variant: 'video', current: 0.8, total: 1 },
+          { label: '문자', variant: 'sms', current: 1, total: 1 },
+        ]}
+      />
       <Outlet />
     </div>
   );
 };
 
 export default MyPage;
+
+{
+  /* <nav>
+        <Link to="coupons">쿠폰</Link> |<Link to="likes">좋아요</Link> |
+        <Link to="events">이벤트</Link> |<Link to="change-plans">요금제 변경</Link>
+      </nav> */
+}


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #53

### 🔎 작업 내용

- [x]  BillSummaryCard 컴포넌트 구현 및 UI 스타일링
- [x]  마이페이지에서 현재 요금제 정보 조회 및 카드 형태로 표시
- [x]  요금제 금액에 원 단위 포맷 적용 (formatPrice 유틸 함수 추가)
- [x]  요금제 사용량 정보를 Progress Bar import해서 활용

### 📸 스크린샷
- 테스트 화면 (내 plan_id는 3번 -> 너겟 31)
- 접었을 때
![image](https://github.com/user-attachments/assets/6e092e11-b2c8-4a90-9638-f1bcd4edb2b1)

- 펼쳤을 때
![image](https://github.com/user-attachments/assets/1d41825c-ec69-4d22-8f33-98dc9371e435)

### :loudspeaker: 전달사항

- 새로 만든 컴포넌트는 /components/BillSummaryCard에 위치
- @radix-ui/react-icons 사용하여 접기/펼치기 버튼 구현
- 추가 디테일적 요소는 수정해서 다시 올리겠습니다~
- 
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
