### PR TITLE
Feat: [EVER-188] 요금제 progressbar 로직 및 무제한 처리 개선, 공유데이터 추가

### DIFF
--- a/src/components/BillSummaryCard/BillSummaryCard.types.ts
+++ b/src/components/BillSummaryCard/BillSummaryCard.types.ts
@@ -1,4 +1,4 @@
-export type UsageVariant = 'data' | 'call' | 'video' | 'sms';
+export type UsageVariant = 'data' | 'call' | 'sharedData' | 'sms';
 
 export interface UsageData {
   label: string;

--- a/src/components/Progress/Progress.stories.tsx
+++ b/src/components/Progress/Progress.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof Progress> = {
         // s
         'data',
         'call',
-        'video',
+        'sharedData',
         'sms',
         'mission',
       ],
@@ -64,7 +64,7 @@ export const PlanVariants: Story = {
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
             <span>데이터 사용량</span>
-            <span>7.2GB / 10GB</span>
+            <span>4GB / 8GB</span>
           </div>
           <Progress variant="data" value={72} />
         </div>
@@ -72,17 +72,17 @@ export const PlanVariants: Story = {
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
             <span>통화 시간</span>
-            <span>850분 / 1000분</span>
+            <span>무제한 + 부가통화 300분</span>
           </div>
           <Progress variant="call" value={85} />
         </div>
 
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
-            <span>영상통화</span>
-            <span>45분 / 60분</span>
+            <span>공유데이터</span>
+            <span>테더링+쉐어링 55GB</span>
           </div>
-          <Progress variant="video" value={75} />
+          <Progress variant="sharedData" value={75} />
         </div>
 
         <div className="space-y-2">
@@ -137,7 +137,7 @@ export const AllVariants: Story = {
           { variant: 'secondary', label: 'Secondary' },
           { variant: 'data', label: '데이터' },
           { variant: 'call', label: '음성통화' },
-          { variant: 'video', label: '영상' },
+          { variant: 'sharedData', label: '공유데이터' },
           { variant: 'sms', label: '문자메시지' },
           { variant: 'mission', label: '미션 진행도' },
         ].map((item) => (

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -18,10 +18,12 @@ export function Progress({
       ? (current / total) * 100
       : typeof value === 'number'
         ? value
-        : undefined;
+        : 0;
 
   const progressValue =
-    typeof rawValue === 'number' && !Number.isNaN(rawValue) ? Math.min(rawValue, 100) : undefined;
+    typeof rawValue === 'number' && !Number.isNaN(rawValue)
+      ? Math.min(Math.max(rawValue, 0), 100)
+      : undefined;
 
   return (
     <div className="relative">

--- a/src/components/Progress/progressVariants.ts
+++ b/src/components/Progress/progressVariants.ts
@@ -6,7 +6,7 @@ export const progressVariants = cva('relative w-full overflow-hidden rounded-ful
       // 요금제용 variants
       data: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-orange-400 dark:[&>*]:bg-blue-400',
       call: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-green-400 dark:[&>*]:bg-green-400',
-      video: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-purple-400 dark:[&>*]:bg-purple-400',
+      sharedData: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-purple-400 dark:[&>*]:bg-purple-400',
       sms: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-pink-400 dark:[&>*]:bg-orange-400',
 
       // 미션용 variant

--- a/src/pages/me/MyPage.tsx
+++ b/src/pages/me/MyPage.tsx
@@ -29,15 +29,37 @@ const MyPage: React.FC = () => {
   if (isLoading) return <p className="p-4">로딩 중...</p>;
   if (error || !plan) return <p className="p-4">요금제를 불러오지 못했습니다.</p>;
 
-  const formatUsage = (label: string, variant: 'data' | 'call' | 'sms', value: string) => {
-    const isUnlimited = value === '무제한';
-    const numeric = isUnlimited ? 1 : Number(value.replace(/GB|분/g, ''));
-
+  const formatUsage = (
+    label: string,
+    variant: 'data' | 'call' | 'sharedData' | 'sms',
+    value: string,
+  ) => {
+    if (!value) {
+      return {
+        label,
+        variant,
+        current: 0,
+        total: 1,
+        displayText: '0',
+      };
+    }
+    const isUnlimited = value.includes('무제한');
+    const total =
+      variant === 'data'
+        ? 30
+        : variant === 'sharedData'
+          ? 60
+          : variant === 'sms'
+            ? 200
+            : variant === 'call'
+              ? 1000
+              : 1;
+    const numeric = isUnlimited ? total : Number(value.replace(/[^0-9.]/g, ''));
     return {
       label,
       variant,
       current: numeric,
-      total: 1,
+      total,
       displayText: isUnlimited ? '무제한' : variant === 'sms' ? `${numeric}건` : value,
     };
   };
@@ -45,6 +67,7 @@ const MyPage: React.FC = () => {
   const usageData = [
     formatUsage('데이터', 'data', plan.data),
     formatUsage('통화', 'call', plan.voice),
+    formatUsage('공유데이터', 'sharedData', plan.share_data),
     formatUsage('문자', 'sms', plan.sms),
   ];
   return (


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #91 

### 🔎 작업 내용

- BillSummaryCard 내부 요금제 ProgressBar가 항상 다 찬 것처럼 보이던 문제 수정
- 데이터/공유데이터/통화/문자 각각에 대해 기준 `total` 값 설정
    - 데이터: 30GB
    - 공유데이터: 60GB
    - 문자: 200건
    - 통화: 1000분
**- "무제한"이 포함된 경우 `current = total`로 처리하여 100% Progress로 표시**
- Progress 컴포넌트 내 `progressValue` fallback 적용으로 0%도 안정적으로 처리
- 마이페이지 접속 → 요금제 카드 확장 → 각 항목에 대해 ProgressBar가 예상대로 표시되는지 확인
- Storybook에서도 각 variant가 정상적으로 색상 표시되는지 확인
- 
### 📸 스크린샷
- storybook에서 테스트 확인
![image](https://github.com/user-attachments/assets/abd598fd-e680-4eb9-94da-ce3d5a1a3714)

- 실제 화면 테스트
<img width="260" alt="image" src="https://github.com/user-attachments/assets/013734d2-0896-4b5c-ba5e-abcb363efbf9" />

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
