### PR TITLE
Feat: [EVER-190] Mypage 내 정보/설정/활동 UI Card 컴포넌트로 통일 및 정렬 개선

### DIFF
--- a/src/components/BillSummaryCard/BillSummaryCard.types.ts
+++ b/src/components/BillSummaryCard/BillSummaryCard.types.ts
@@ -1,4 +1,4 @@
-export type UsageVariant = 'data' | 'call' | 'video' | 'sms';
+export type UsageVariant = 'data' | 'call' | 'sharedData' | 'sms';
 
 export interface UsageData {
   label: string;

--- a/src/components/Progress/Progress.stories.tsx
+++ b/src/components/Progress/Progress.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof Progress> = {
         // s
         'data',
         'call',
-        'video',
+        'sharedData',
         'sms',
         'mission',
       ],
@@ -64,7 +64,7 @@ export const PlanVariants: Story = {
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
             <span>데이터 사용량</span>
-            <span>7.2GB / 10GB</span>
+            <span>4GB / 8GB</span>
           </div>
           <Progress variant="data" value={72} />
         </div>
@@ -72,17 +72,17 @@ export const PlanVariants: Story = {
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
             <span>통화 시간</span>
-            <span>850분 / 1000분</span>
+            <span>무제한 + 부가통화 300분</span>
           </div>
           <Progress variant="call" value={85} />
         </div>
 
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
-            <span>영상통화</span>
-            <span>45분 / 60분</span>
+            <span>공유데이터</span>
+            <span>테더링+쉐어링 55GB</span>
           </div>
-          <Progress variant="video" value={75} />
+          <Progress variant="sharedData" value={75} />
         </div>
 
         <div className="space-y-2">
@@ -137,7 +137,7 @@ export const AllVariants: Story = {
           { variant: 'secondary', label: 'Secondary' },
           { variant: 'data', label: '데이터' },
           { variant: 'call', label: '음성통화' },
-          { variant: 'video', label: '영상' },
+          { variant: 'sharedData', label: '공유데이터' },
           { variant: 'sms', label: '문자메시지' },
           { variant: 'mission', label: '미션 진행도' },
         ].map((item) => (

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -18,10 +18,12 @@ export function Progress({
       ? (current / total) * 100
       : typeof value === 'number'
         ? value
-        : undefined;
+        : 0;
 
   const progressValue =
-    typeof rawValue === 'number' && !Number.isNaN(rawValue) ? Math.min(rawValue, 100) : undefined;
+    typeof rawValue === 'number' && !Number.isNaN(rawValue)
+      ? Math.min(Math.max(rawValue, 0), 100)
+      : undefined;
 
   return (
     <div className="relative">

--- a/src/components/Progress/progressVariants.ts
+++ b/src/components/Progress/progressVariants.ts
@@ -6,7 +6,7 @@ export const progressVariants = cva('relative w-full overflow-hidden rounded-ful
       // 요금제용 variants
       data: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-orange-400 dark:[&>*]:bg-blue-400',
       call: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-green-400 dark:[&>*]:bg-green-400',
-      video: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-purple-400 dark:[&>*]:bg-purple-400',
+      sharedData: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-purple-400 dark:[&>*]:bg-purple-400',
       sms: 'bg-gray-100 dark:bg-gray-900/30 [&>*]:bg-pink-400 dark:[&>*]:bg-orange-400',
 
       // 미션용 variant

--- a/src/pages/me/MyPage.tsx
+++ b/src/pages/me/MyPage.tsx
@@ -29,15 +29,37 @@ const MyPage: React.FC = () => {
   if (isLoading) return <p className="p-4">로딩 중...</p>;
   if (error || !plan) return <p className="p-4">요금제를 불러오지 못했습니다.</p>;
 
-  const formatUsage = (label: string, variant: 'data' | 'call' | 'sms', value: string) => {
-    const isUnlimited = value === '무제한';
-    const numeric = isUnlimited ? 1 : Number(value.replace(/GB|분/g, ''));
-
+  const formatUsage = (
+    label: string,
+    variant: 'data' | 'call' | 'sharedData' | 'sms',
+    value: string,
+  ) => {
+    if (!value) {
+      return {
+        label,
+        variant,
+        current: 0,
+        total: 1,
+        displayText: '0',
+      };
+    }
+    const isUnlimited = value.includes('무제한');
+    const total =
+      variant === 'data'
+        ? 30
+        : variant === 'sharedData'
+          ? 60
+          : variant === 'sms'
+            ? 200
+            : variant === 'call'
+              ? 1000
+              : 1;
+    const numeric = isUnlimited ? total : Number(value.replace(/[^0-9.]/g, ''));
     return {
       label,
       variant,
       current: numeric,
-      total: 1,
+      total,
       displayText: isUnlimited ? '무제한' : variant === 'sms' ? `${numeric}건` : value,
     };
   };
@@ -45,6 +67,7 @@ const MyPage: React.FC = () => {
   const usageData = [
     formatUsage('데이터', 'data', plan.data),
     formatUsage('통화', 'call', plan.voice),
+    formatUsage('공유데이터', 'sharedData', plan.share_data),
     formatUsage('문자', 'sms', plan.sms),
   ];
   return (

--- a/src/pages/me/MyPage.tsx
+++ b/src/pages/me/MyPage.tsx
@@ -1,5 +1,6 @@
 import { BillSummaryCard } from '@/components/ui/billsummarycard';
 import React from 'react';
+import { Card, CardContent } from '@/components/Card';
 import { useQuery } from '@tanstack/react-query';
 import { fetchCurrentPlan } from '@/apis/plan/getCurrentPlan';
 import { useUserProfile } from '@/stores/useUserProfile';
@@ -86,28 +87,37 @@ const MyPage: React.FC = () => {
       />
       <h3 className="title-2 mb-4 mt-4">내 정보</h3>
       <div className="grid grid-cols-2 gap-4">
-        <Link
-          to="coupons"
-          className="w-full py-3 rounded-lg bg-card text-card-foreground shadow-sm hover:shadow-md transition-all flex items-center justify-center gap-2"
-        >
-          <Ticket className="w-5 h-5 text-yellow-600" />
-          <span className="caption-1">보유 쿠폰</span>
-          <span className="caption-1 font-bold ml-1">{coupons.length}개</span>
+        <Link to="coupons">
+          <Card clickable>
+            <CardContent className="flex items-center justify-center gap-1.5 py-2.5 leading-none">
+              <Ticket className="w-[18px] h-[18px] text-yellow-600 shrink-0" />
+              <span className="caption-1 whitespace-nowrap">보유 쿠폰</span>
+              <span className="caption-1 font-bold ml-1 whitespace-nowrap">{coupons.length}개</span>
+            </CardContent>
+          </Card>
         </Link>
-        <div className="w-full py-3 rounded-lg bg-card text-card-foreground shadow-sm hover:shadow-md transition-all flex items-center justify-center gap-2">
-          <Coins className="w-5 h-5 text-blue-600" />
-          <span className="caption-1">보유 포인트</span>
-          <span className="caption-1 font-bold ml-1">1,250P</span>
-        </div>
+
+        <Card clickable>
+          <CardContent className="flex items-center justify-center gap-1.5 py-2.5 leading-none">
+            <Coins className="w-[18px] h-[18px] text-blue-600 shrink-0" />
+            <span className="caption-1 whitespace-nowrap">보유 포인트</span>
+            <span className="caption-1 font-bold ml-1 whitespace-nowrap">1,250P</span>
+          </CardContent>
+        </Card>
       </div>
+
       <h3 className="title-2 mb-4 mt-4">요금제 설정</h3>
       <div className="grid grid-cols-2 gap-4">
-        <button className="w-full py-3 rounded-lg bg-card text-card-foreground shadow-sm hover:shadow-md transition-all caption-1">
-          요금제 해지
-        </button>
-        <button className="w-full py-3 rounded-lg bg-card text-card-foreground shadow-sm hover:shadow-md transition-all caption-1">
-          요금제 변경
-        </button>
+        <Card clickable>
+          <CardContent className="text-center py-2.5 caption-1  leading-tight">
+            요금제 해지
+          </CardContent>
+        </Card>
+        <Card clickable>
+          <CardContent className="text-center py-2.5 caption-1  leading-tight">
+            요금제 변경
+          </CardContent>
+        </Card>
       </div>
 
       <div>
@@ -115,22 +125,31 @@ const MyPage: React.FC = () => {
           내 활동 <span className="text-red-400 font-bold">4</span>개
         </h3>
         <div className="grid grid-cols-2 gap-4">
-          <button className="bg-card text-card-foreground flex flex-col items-center justify-center gap-1 rounded-xl py-4 shadow-sm cursor-pointer transition-all border border-gray-50 hover:shadow-md">
-            <Package className="w-6 h-6" />
-            <span className="caption-1">구독상품 목록</span>
-          </button>
-          <button className="bg-card text-card-foreground flex flex-col items-center justify-center gap-1 rounded-xl py-4 shadow-sm cursor-pointer transition-all border border-gray-50 hover:shadow-md">
-            <ClipboardCheck className="w-6 h-6" />
-            <span className="caption-1">미션 목록</span>
-          </button>
-          <button className="bg-card text-card-foreground flex flex-col items-center justify-center gap-1 rounded-xl py-4 shadow-sm cursor-pointer transition-all border border-gray-50 hover:shadow-md">
-            <Stamp className="w-6 h-6" />
-            <span className="caption-1">이번달 출석 기록</span>
-          </button>
-          <button className="bg-card text-card-foreground flex flex-col items-center justify-center gap-1 rounded-xl py-4 shadow-sm cursor-pointer transition-all border border-gray-50 hover:shadow-md">
-            <FolderHeart className="w-6 h-6" />
-            <span className="caption-1">좋아요한 쿠폰 목록</span>
-          </button>
+          <Card clickable>
+            <CardContent className="flex flex-col items-center justify-center py-4 gap-1 whitespace-nowrap text-center">
+              <Package className="w-6 h-6" />
+              <span className="caption-1">구독상품 목록</span>
+            </CardContent>
+          </Card>
+
+          <Card clickable>
+            <CardContent className="flex flex-col items-center justify-center py-4 gap-1 whitespace-nowrap text-center">
+              <ClipboardCheck className="w-6 h-6" />
+              <span className="caption-1">미션 목록</span>
+            </CardContent>
+          </Card>
+          <Card clickable>
+            <CardContent className="flex flex-col items-center justify-center py-4 gap-1 whitespace-nowrap text-center">
+              <Stamp className="w-6 h-6" />
+              <span className="caption-1">이번달 출석 기록</span>
+            </CardContent>
+          </Card>
+          <Card clickable>
+            <CardContent className="flex flex-col items-center justify-center py-4 gap-1 whitespace-nowrap text-center">
+              <FolderHeart className="w-6 h-6" />
+              <span className="caption-1">좋아요한 쿠폰 목록</span>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #93 

### 🔎 작업 내용

- 보유 쿠폰, 보유 포인트를 <Card> + <CardContent> 구조로 변경
- 아이콘 크기 조정
- whitespace-nowrap, shrink-0, leading-none 등으로 텍스트 정렬 개선
- 요금제 해지, 요금제 변경 카드 높이 축소 (py-3 → py-2.5)
- 내 활동 4종 (구독상품 목록, 미션 목록, 출석 기록, 좋아요 쿠폰) 카드도 Card로 통일
- 줄바꿈 문제 해결 (whitespace-nowrap, text-center)
- 중복 스타일 제거 및 gap, padding 조정으로 전체 UI 균형 조정


### 📸 스크린샷
**- Card 컴포넌트로 통일한 거라서 보이는 화면은 이전과 유사**
<img width="217" alt="image" src="https://github.com/user-attachments/assets/1a7ae72e-cb46-460c-9f04-87d31c671864" />
<img width="223" alt="image" src="https://github.com/user-attachments/assets/8fbc89b9-ea7d-41c8-b27f-b1b61401eb92" />


### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
