### PR TITLE
Fix: [EVER-207] 마이페이지 쿠폰 보유 수 표시 오류 수정

### DIFF
--- a/src/pages/me/MyPage.tsx
+++ b/src/pages/me/MyPage.tsx
@@ -26,6 +26,7 @@ const MyPage: React.FC = () => {
     queryKey: ['userCoupons'],
     queryFn: fetchUserCoupons,
   });
+  const availableCoupons = coupons.filter((c) => c.isUsed === false);
 
   if (isLoading) return <p className="p-4">로딩 중...</p>;
   if (error || !plan) return <p className="p-4">요금제를 불러오지 못했습니다.</p>;
@@ -92,7 +93,9 @@ const MyPage: React.FC = () => {
             <CardContent className="flex items-center justify-center gap-1.5 py-2.5 leading-none">
               <Ticket className="w-[18px] h-[18px] text-yellow-600 shrink-0" />
               <span className="caption-1 whitespace-nowrap">보유 쿠폰</span>
-              <span className="caption-1 font-bold ml-1 whitespace-nowrap">{coupons.length}개</span>
+              <span className="caption-1 font-bold ml-1 whitespace-nowrap">
+                {availableCoupons.length}개
+              </span>
             </CardContent>
           </Card>
         </Link>


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #116 

### 🔎 작업 내용

- isUsed === 0으로 비교하던 쿠폰 필터 조건을 !isUsed로 수정
- API 응답에서 isUsed가 boolean 타입(true/false)으로 오는 것 반영
- 마이페이지에서 실제 미사용 쿠폰만 정확히 카운트하여 표시

### 📸 스크린샷
- 사용한 쿠폰(빨간색) 제외 하고 나머지 카운트해서 표시하는것 확인
![image](https://github.com/user-attachments/assets/e2bcd023-dc39-48a0-81de-a0777dbb5e75)

- 쿠폰함에서도 숫자와 리스트 확인
![image](https://github.com/user-attachments/assets/81e19da7-e568-4434-8ee9-5308b7861fcc)


## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
