### PR TITLE
Feat: [EVER-206] 출석 미션 진행도 및 보상 수령 기능 구현

### DIFF
--- a/src/apis/mission/receiveMissionReward.ts
+++ b/src/apis/mission/receiveMissionReward.ts
@@ -1,0 +1,6 @@
+import { apiWithToken } from '@/lib/api/apiconfig';
+
+export const receiveMissionReward = async (missionId: number) => {
+  const response = await apiWithToken.patch(`/missions/${missionId}/reward`);
+  return response.data;
+};

--- a/src/apis/mission/updateProgress.ts
+++ b/src/apis/mission/updateProgress.ts
@@ -1,0 +1,5 @@
+import { apiWithToken } from '@/lib/api/apiconfig';
+
+export const updateProgress = async (missionId: number) => {
+  await apiWithToken.patch(`/missions/${missionId}/progress`);
+};

--- a/src/hooks/useAttendance.ts
+++ b/src/hooks/useAttendance.ts
@@ -1,6 +1,8 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { getTodayAttendance, postTodayAttendance } from '@/apis/attendance/attendance';
 import { useUserProfile } from '@/stores/useUserProfile';
+import { updateProgress } from '@/apis/mission/updateProgress'; // 미션 진행도 API 추가
+import { toast } from 'sonner';
 
 export const useAttendance = () => {
   const { data: profile } = useUserProfile();
@@ -15,11 +17,37 @@ export const useAttendance = () => {
     enabled: !!profile?.userId,
   });
 
+  // const { mutate: checkAttendance, isPending } = useMutation({
+  //   mutationFn: async () => {
+  //     await postTodayAttendance(); // ✅ 출석 API 호출
+  //     await updateProgress(3); // ✅ 미션 ID 3: 연속 출석 미션 +1
+  //   },
+  //   onSuccess: () => {
+  //     refetchAttendance(); // 출석 상태 최신화
+  //     toast.success('출석 완료!');
+  //   },
+  //   onError: () => {
+  //     toast.error('이미 출석하셨거나 오류가 발생했어요!');
+  //   },
+  // });
+
   const { mutate: checkAttendance, isPending } = useMutation({
-    mutationFn: postTodayAttendance,
+    mutationFn: async () => {
+      console.log('🟡 출석 요청 시작');
+      await postTodayAttendance(); // 출석 요청
+      console.log('🟢 출석 성공 → 진행도 업데이트 시도');
+
+      await updateProgress(3); // 미션 ID 3 진행도 +1
+      console.log('🟢 미션 진행도 업데이트 성공');
+    },
     onSuccess: () => {
-      console.log('✅ 출석 성공 → refetch 실행');
-      refetchAttendance(); // ✅ 출석 후 바로 상태 업데이트
+      console.log('🟢 전체 성공 → 상태 리패치');
+      refetchAttendance();
+      toast.success('출석 완료!');
+    },
+    onError: (error) => {
+      console.error('❌ 출석 또는 미션 업데이트 실패:', error);
+      toast.error('이미 출석하셨거나 오류가 발생했어요!');
     },
   });
 

--- a/src/hooks/useMissions.ts
+++ b/src/hooks/useMissions.ts
@@ -1,9 +1,37 @@
 import { useQuery } from '@tanstack/react-query';
 import { getUserMissions } from '@/apis/mission/getUserMissions';
+import { receiveMissionReward } from '@/apis/mission/receiveMissionReward';
+import { toast } from 'sonner';
 
 export const useMissions = () => {
   return useQuery({
     queryKey: ['missions', 'me'],
     queryFn: getUserMissions,
   });
+};
+
+export const useMissionActions = () => {
+  const receiveReward = async (missionId: number) => {
+    try {
+      const result = await receiveMissionReward(missionId);
+      toast.success(result.message ?? '보상을 수령했어요!');
+
+      // ✅ 미션 리스트 리패치 필요 (상태 COM → REC 변경)
+      // 예: queryClient.invalidateQueries(['missions']);
+    } catch (e: unknown) {
+      if (
+        typeof e === 'object' &&
+        e !== null &&
+        'response' in e &&
+        typeof (e as { response?: { data?: { message?: string } } }).response?.data?.message ===
+          'string'
+      ) {
+        toast.error((e as { response: { data: { message: string } } }).response.data.message);
+      } else {
+        toast.error('보상 수령에 실패했어요');
+      }
+    }
+  };
+
+  return { receiveReward };
 };


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> #115

### 🔎 작업 내용

- [x] 출석 성공 시 미션 ID 3번(연속 출석 5회 달성) 자동 진행도 +1 연동
- [x] 미션 완료(COM) 상태일 경우 "수령하기" 버튼 노출 및 활성화
- [x] 진행도 목표치(target_count) 도달 시 상태가 COM으로 전환되도록 백엔드 로직 반영 
- [x] 상태 변경 후 미션 리스트 자동 리패치 (invalidateQueries 사용)
- [x] 토스트로 성공/실패 메시지 사용자에게 알림 처리

### 📸 스크린샷
#### 보상 수령 전
![image](https://github.com/user-attachments/assets/5349a964-929c-4413-bb18-61625d56ba74)

#### 보상 수령 후
![image](https://github.com/user-attachments/assets/606aad7b-813e-437f-b314-d9d6d94c0fe6)

#### 보상 수령 후 DB 반영까지 확인 완료
**1) 유저 테이블 point 증가**
![image](https://github.com/user-attachments/assets/de93b222-c350-4a06-8bdf-04dece249a57)

**2) 유저 미션 테이블 미션 status COM -> REC 로 바뀜**
![image](https://github.com/user-attachments/assets/fb12690c-2715-44d2-b966-d82c4e8f29ef)


### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
