### PR TITLE
Feat: [EVER-217] 마이페이지 및 홈화면 기능 개선 및 사용자 데이터 반영

### DIFF
--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useUserProfile } from '@/stores/useUserProfile';
-import { logout as apiLogout } from '@/utils/auth';
 import Subscription from './Subscription';
 import { Banner } from '@/components/Banner';
 import { Button } from '@/components/Button';
 import { IMAGES } from '@/constant/imagePath';
-import { sonnerToast } from '@/components/Sooner';
 import { useQuery } from '@tanstack/react-query';
 import { fetchCurrentPlan } from '@/apis/plan/getCurrentPlan';
 import { BillSummaryCard } from '@/components/ui/billsummarycard';
@@ -15,19 +13,8 @@ import { BillSummaryCard } from '@/components/ui/billsummarycard';
 const Home: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { isLoggedIn, logout: stateLogout } = useAuthStore();
+  const { isLoggedIn } = useAuthStore();
   const { data: profile, isLoading: profileLoading } = useUserProfile();
-
-  const handleLogout = useCallback(async () => {
-    try {
-      await apiLogout();
-      stateLogout();
-      sonnerToast('로그아웃되었습니다.');
-      navigate('/login');
-    } catch {
-      sonnerToast.error('로그아웃 실패');
-    }
-  }, [navigate, stateLogout]);
 
   const { data: plan, isLoading: planLoading } = useQuery({
     queryKey: ['currentPlan'],

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -56,7 +56,6 @@ const Home: React.FC = () => {
     };
   };
 
-  // 3. usageData 가공
   const usageData = [
     formatUsage('데이터', 'data', plan?.data),
     formatUsage('통화', 'call', plan?.voice),

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -8,6 +8,9 @@ import { Banner } from '@/components/Banner';
 import { Button } from '@/components/Button';
 import { IMAGES } from '@/constant/imagePath';
 import { sonnerToast } from '@/components/Sooner';
+import { useQuery } from '@tanstack/react-query';
+import { fetchCurrentPlan } from '@/apis/plan/getCurrentPlan';
+import { BillSummaryCard } from '@/components/ui/billsummarycard';
 
 const Home: React.FC = () => {
   const navigate = useNavigate();
@@ -26,6 +29,53 @@ const Home: React.FC = () => {
     }
   }, [navigate, stateLogout]);
 
+  const { data: plan, isLoading: planLoading } = useQuery({
+    queryKey: ['currentPlan'],
+    queryFn: fetchCurrentPlan,
+  });
+
+  const formatUsage = (
+    label: string,
+    variant: 'data' | 'call' | 'sharedData' | 'sms',
+    value: string,
+  ) => {
+    if (!value) {
+      return {
+        label,
+        variant,
+        current: 0,
+        total: 1,
+        displayText: '0',
+      };
+    }
+    const isUnlimited = value.includes('무제한');
+    const total =
+      variant === 'data'
+        ? 30
+        : variant === 'sharedData'
+          ? 60
+          : variant === 'sms'
+            ? 200
+            : variant === 'call'
+              ? 1000
+              : 1;
+    const numeric = isUnlimited ? total : Number(value.replace(/[^0-9.]/g, ''));
+    return {
+      label,
+      variant,
+      current: numeric,
+      total,
+      displayText: isUnlimited ? '무제한' : variant === 'sms' ? `${numeric}건` : value,
+    };
+  };
+
+  // 3. usageData 가공
+  const usageData = [
+    formatUsage('데이터', 'data', plan?.data),
+    formatUsage('통화', 'call', plan?.voice),
+    formatUsage('공유데이터', 'sharedData', plan?.share_data),
+    formatUsage('문자', 'sms', plan?.sms),
+  ];
   return (
     <div>
       <Banner
@@ -48,24 +98,18 @@ const Home: React.FC = () => {
       />
 
       {isLoggedIn ? (
-        profileLoading ? (
+        profileLoading || planLoading ? (
           <div className="flex justify-center">프로필 정보 로딩 중…</div>
         ) : (
-          <div className="relative flex flex-col items-center justify-center flex-1 px-6 py-12 min-h-[20vh] bg-[#F4DE75] rounded-lg text-center shadow-md mb-4 overflow-hidden">
-            <div className="absolute -top-10 -left-10 w-40 h-40 bg-white/20 rounded-full z-0" />
-            <div className="absolute bottom-0 -right-12 w-44 h-44 bg-white/20 rounded-full z-0" />
-            <div className="relative z-10">
-              <h1 className="text-2xl font-bold mb-4">안녕하세요, {profile?.name ?? '회원'}님!</h1>
-              <p className="mb-2">플랜 ID: {profile?.planId}</p>
-              <p className="mb-2">포인트: {profile?.point}</p>
-              <p className="mb-4">출석 연속일: {profile?.attendanceStreak}일</p>
-              <button
-                onClick={handleLogout}
-                className="px-6 py-2 bg-red-500 text-white rounded hover:bg-red-600 transition"
-              >
-                로그아웃
-              </button>
-            </div>
+          <div className="mb-4">
+            <h1 className="text-xl font-bold">내 요금제</h1>
+            <BillSummaryCard
+              phoneNumber={profile?.phoneNumber ?? '010-****-****'}
+              planName={plan.name}
+              month={`${new Date().getMonth() + 1}월`}
+              amount={Number(plan.price)}
+              usageData={usageData}
+            />
           </div>
         )
       ) : (

--- a/src/pages/me/MyPage.tsx
+++ b/src/pages/me/MyPage.tsx
@@ -100,7 +100,7 @@ const MyPage: React.FC = () => {
           </Card>
         </Link>
 
-        <Card clickable>
+        <Card className="cursor-default hover:bg-transparent">
           <CardContent className="flex items-center justify-center gap-1.5 py-2.5 leading-none">
             <Coins className="w-[18px] h-[18px] text-blue-600 shrink-0" />
             <span className="caption-1 whitespace-nowrap">보유 포인트</span>
@@ -136,19 +136,23 @@ const MyPage: React.FC = () => {
               </CardContent>
             </Card>
           </Link>
+          <Link to="/mission" state={{ scrollTo: 'mission-list' }}>
+            <Card clickable>
+              <CardContent className="flex flex-col items-center justify-center py-4 gap-1 whitespace-nowrap text-center">
+                <ClipboardCheck className="w-6 h-6" />
+                <span className="caption-1">미션 목록</span>
+              </CardContent>
+            </Card>
+          </Link>
+          <Link to="/mission" state={{ scrollTo: 'attendance' }}>
+            <Card clickable>
+              <CardContent className="flex flex-col items-center justify-center py-4 gap-1 whitespace-nowrap text-center">
+                <Stamp className="w-6 h-6" />
+                <span className="caption-1">이번달 출석 기록</span>
+              </CardContent>
+            </Card>
+          </Link>
 
-          <Card clickable>
-            <CardContent className="flex flex-col items-center justify-center py-4 gap-1 whitespace-nowrap text-center">
-              <ClipboardCheck className="w-6 h-6" />
-              <span className="caption-1">미션 목록</span>
-            </CardContent>
-          </Card>
-          <Card clickable>
-            <CardContent className="flex flex-col items-center justify-center py-4 gap-1 whitespace-nowrap text-center">
-              <Stamp className="w-6 h-6" />
-              <span className="caption-1">이번달 출석 기록</span>
-            </CardContent>
-          </Card>
           <Card clickable>
             <CardContent className="flex flex-col items-center justify-center py-4 gap-1 whitespace-nowrap text-center">
               <FolderHeart className="w-6 h-6" />

--- a/src/pages/me/MyPage.tsx
+++ b/src/pages/me/MyPage.tsx
@@ -104,7 +104,9 @@ const MyPage: React.FC = () => {
           <CardContent className="flex items-center justify-center gap-1.5 py-2.5 leading-none">
             <Coins className="w-[18px] h-[18px] text-blue-600 shrink-0" />
             <span className="caption-1 whitespace-nowrap">보유 포인트</span>
-            <span className="caption-1 font-bold ml-1 whitespace-nowrap">1,250P</span>
+            <span className="caption-1 font-bold ml-1 whitespace-nowrap">
+              {profile?.point?.toLocaleString() ?? '0'}P
+            </span>
           </CardContent>
         </Card>
       </div>

--- a/src/pages/mission/Mission.tsx
+++ b/src/pages/mission/Mission.tsx
@@ -1,6 +1,6 @@
 // pages/mission/Mission.tsx
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useEffect, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { AttendanceBanner } from './Attendance';
 import { AttendanceCalendar } from './Attendance/AttendanceCalendar';
 import { MissionList } from '@/components/MissionList/MissionList';
@@ -8,6 +8,19 @@ import { MissionList } from '@/components/MissionList/MissionList';
 
 const MissionPage: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const missionRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const scrollTarget = location.state?.scrollTo;
+
+    if (scrollTarget === 'mission-list' && missionRef.current) {
+      setTimeout(() => {
+        missionRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }, 100);
+    } else {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [location]);
 
   return (
     <div className="p-4">
@@ -25,7 +38,7 @@ const MissionPage: React.FC = () => {
 
       <AttendanceCalendar />
 
-      <div className="mt-10">
+      <div ref={missionRef} className="mt-10">
         <h2 className="text-lg font-bold text-gray-900 mb-4">진행 중인 미션</h2>
         <MissionList />
       </div>


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #130 
### 🔎 작업 내용

**마이페이지 (pages/me/MyPage.tsx)**
- 보유 포인트: 임의값(1250P) 제거 → 실제 사용자 포인트(profile.point) 반영
   - toLocaleString()으로 쉼표 처리 + "P" 접미사
   - 클릭/hover 불가능한 카드로 설정 (clickable 제거, hover:bg-transparent)

- 출석 기록 / 미션 목록 카드 클릭 시 → /mission 이동 + 해당 위치로 스크롤
  - Link의 state로 scrollTo: 'attendance' | 'mission-list' 전달

**미션 페이지 (pages/mission/Mission.tsx)**
- location.state.scrollTo에 따라 진입 후 스크롤 동작 처리
    - 'attendance' → 출석 스탬프 영역 (attendanceRef)
    - 'mission-list' → 진행 중인 미션 영역 (missionRef)
- 각각 ref를 통한 scrollIntoView({ behavior: 'smooth' }) 적용


**홈 화면 (pages/Home.tsx)**
- BillSummaryCard에서 사용자 이름, 전화번호, 요금제 정보 반영
- handleLogout 함수 정의만 되어 사용되지 않아 제거
- 로그인 상태/데이터 로딩 여부 조건 정리


### 📸 스크린샷
- 로그인 안한 유저
![image](https://github.com/user-attachments/assets/c3489f02-8f4b-4f4a-9154-f7fb169149ac)
- 로그인 한 유저
![image](https://github.com/user-attachments/assets/b21cbb7f-4b6f-40a3-8256-bdb72dd1098f)
- 마이페이지에서 포인트 연동
![image](https://github.com/user-attachments/assets/320a8652-9010-476d-a2bc-7fefb7cb4452)


### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
