### PR TITLE
Feat: [EVER-224] 출석 완료 후 streak 기반 미션 진행도 즉시 반영

### DIFF
--- a/src/apis/mission/getUserMissions.ts
+++ b/src/apis/mission/getUserMissions.ts
@@ -11,11 +11,11 @@ export const getUserMissions = async (): Promise<Mission[]> => {
       description: m.description ?? '',
       image_url: m.image_url ?? '',
       completed_at: m.completed_at ?? '',
-      type: m.type as MissionType, // ✅ 필요 시 임시 처리 or mission에서 type join 필요
+      type: m.type as MissionType, // 필요 시 임시 처리 or mission에서 type join 필요
       target_count: m.target_count,
       current_progress: m.progress_count,
       reward_point: m.reward_point,
-      is_completed: m.status !== 'INP', // ✅ 핵심!
+      is_completed: m.status !== 'INP',
       status: m.status,
     }),
   );

--- a/src/hooks/useAttendance.ts
+++ b/src/hooks/useAttendance.ts
@@ -8,6 +8,7 @@ export const useAttendance = () => {
   const { data: userData } = useUserProfile();
   const queryClient = useQueryClient();
   const userName = userData?.name ?? '사용자';
+  const userId = userData?.id;
 
   const today = new Date();
   const year = today.getFullYear();
@@ -49,6 +50,10 @@ export const useAttendance = () => {
       queryClient.invalidateQueries({ queryKey: ['attendance', year, month] });
       queryClient.invalidateQueries({ queryKey: ['attendance', 'today'] });
       queryClient.invalidateQueries({ queryKey: ['missions'] });
+
+      if (userId) {
+        queryClient.invalidateQueries({ queryKey: ['userProfile', userId] });
+      }
     },
   });
 

--- a/src/hooks/useAttendance.ts
+++ b/src/hooks/useAttendance.ts
@@ -48,6 +48,7 @@ export const useAttendance = () => {
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['attendance', year, month] });
       queryClient.invalidateQueries({ queryKey: ['attendance', 'today'] });
+      queryClient.invalidateQueries({ queryKey: ['missions'] });
     },
   });
 

--- a/src/pages/mission/Mission.tsx
+++ b/src/pages/mission/Mission.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { AttendanceBanner } from './Attendance';
 import { AttendanceCalendar } from './Attendance/AttendanceCalendar';
 import { MissionList } from '@/components/MissionList/MissionList';
-// import type { Mission } from '@/components/MissionList/MissionList.types';
 
 const MissionPage: React.FC = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> #139

### 🔎 작업 내용

- [x] 출석 체크 후 `userProfile` 쿼리 invalidate 처리 추가
- [x] 출석 미션이 `attendanceStreak` 기반으로 실시간 반영되도록 개선
- [x] `userId` 존재 시에만 무효화 처리로 안전성 확보

### 📸 스크린샷

### :loudspeaker: 전달사항
- 이제 출석 후 달력, 배너, 미션 상태까지 전부 실시간으로 반영됩니다.
- 기존 `userProfile` 쿼리가 캐시에 묶여 stale일 수 있는 문제를 해결했습니다.

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
