### PR TITLE
Feat: [EVER-228] 사용량 기반 API 연동 및 챗봇 페이지에 버튼 추가 

### DIFF
--- a/src/apis/chat/usage.ts
+++ b/src/apis/chat/usage.ts
@@ -1,0 +1,31 @@
+import { API_BASE_URL } from '@/lib/api/apiconfig';
+import { StreamingThrottle } from '@/lib/streaming/StreamingThrottle';
+import { processStreamWithThrottle } from '@/lib/streaming/streamProcessor';
+import { createStreamingHeaders, STREAMING_PRESETS } from '@/lib/streaming/utils';
+import type { UsageRecommendationRequest, UsageRecommendationChunk } from '@/lib/streaming/types';
+export type { UsageRecommendationRequest, UsageRecommendationChunk } from '@/lib/streaming/types';
+
+/**
+ * 사용량 기반 요금제 추천 스트리밍
+ * @param req 추천 요청 데이터
+ * @param onChunk 청크 처리 콜백
+ */
+export async function getUsageRecommendationStreaming(
+  req: UsageRecommendationRequest,
+  onChunk: (chunk: UsageRecommendationChunk) => void,
+): Promise<void> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/chat/usage`, {
+      method: 'POST',
+      headers: createStreamingHeaders(true), // 인증 필요
+      body: JSON.stringify(req),
+      credentials: 'include', // JWT 쿠키 포함
+    });
+
+    const throttle = new StreamingThrottle(STREAMING_PRESETS.RECOMMENDATION);
+    await processStreamWithThrottle(response, onChunk, throttle);
+  } catch (error) {
+    console.error('Usage recommendation streaming error:', error);
+    throw new Error('사용량 기반 추천 요청 실패');
+  }
+}

--- a/src/components/BaseSwiper/BaseSwiper.tsx
+++ b/src/components/BaseSwiper/BaseSwiper.tsx
@@ -12,15 +12,17 @@ interface BaseSwiperProps<T> {
 }
 
 export function BaseSwiper<T>({ items, renderItem }: BaseSwiperProps<T>) {
+  const isSingleSlide = items.length === 1;
+
   return (
     <div className="w-full max-w-sm mx-auto">
       <Swiper
         modules={[Pagination, Navigation]}
         spaceBetween={16}
         slidesPerView={1}
-        pagination={{ clickable: true }}
-        navigation
-        className="!pb-12"
+        pagination={isSingleSlide ? false : { clickable: true }}
+        navigation={!isSingleSlide}
+        className={isSingleSlide ? '' : '!pb-12'}
       >
         {items.map((item, index) => (
           <SwiperSlide key={index}>{renderItem(item)}</SwiperSlide>

--- a/src/components/UsageAnalysisCard/UsageAnalysisCard.tsx
+++ b/src/components/UsageAnalysisCard/UsageAnalysisCard.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Smartphone,
+  Phone,
+  MessageSquare,
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  CheckCircle,
+  Wifi,
+  DollarSign,
+} from 'lucide-react';
+import type { UsageAnalysisData } from '@/types/streaming';
+import { formatPrice } from '@/utils/priceUtils';
+import { cn } from '@/lib/utils';
+
+interface UsageAnalysisCardProps {
+  data: UsageAnalysisData;
+  className?: string;
+}
+
+// 사용률에 따른 상태 및 색상 결정
+const getUsageStatus = (percentage: number) => {
+  if (percentage >= 90) {
+    return {
+      level: 'critical',
+      color: 'text-negative',
+      bgColor: 'bg-negative-bg',
+      borderColor: 'border-negative',
+      icon: AlertTriangle,
+      progressColor: 'bg-negative',
+    };
+  }
+  if (percentage >= 70) {
+    return {
+      level: 'warning',
+      color: 'text-cautionary',
+      bgColor: 'bg-cautionary-bg',
+      borderColor: 'border-cautionary',
+      icon: TrendingUp,
+      progressColor: 'bg-cautionary',
+    };
+  }
+  if (percentage >= 30) {
+    return {
+      level: 'good',
+      color: 'text-positive',
+      bgColor: 'bg-positive-bg',
+      borderColor: 'border-positive',
+      icon: CheckCircle,
+      progressColor: 'bg-positive',
+    };
+  }
+  return {
+    level: 'excellent',
+    color: 'text-brand-darkblue',
+    bgColor: 'bg-brand-darkblue-light',
+    borderColor: 'border-brand-darkblue',
+    icon: TrendingDown,
+    progressColor: 'bg-brand-darkblue',
+  };
+};
+
+// 데이터 용량 포맷팅 (MB → GB)
+const formatDataUsage = (mb: number) => {
+  if (mb >= 1000) {
+    return `${(mb / 1000).toFixed(1)}GB`;
+  }
+  return `${mb}MB`;
+};
+
+// 사용률에 따른 권장사항
+const getRecommendation = (percentage: number) => {
+  if (percentage >= 90) return '요금제 업그레이드를 고려해보세요';
+  if (percentage >= 70) return '사용량을 확인하며 이용하세요';
+  if (percentage >= 30) return '현재 요금제가 적합합니다';
+  return '더 저렴한 요금제도 검토해보세요';
+};
+
+// 원형 진행률 컴포넌트
+const CircularProgress: React.FC<{ percentage: number; size?: number; strokeWidth?: number }> = ({
+  percentage,
+  size = 80,
+  strokeWidth = 6,
+}) => {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = radius * 2 * Math.PI;
+  const strokeDasharray = `${circumference} ${circumference}`;
+  const strokeDashoffset = circumference - (percentage / 100) * circumference;
+  const status = getUsageStatus(percentage);
+
+  return (
+    <div className="relative inline-flex items-center justify-center">
+      <svg width={size} height={size} className="transform -rotate-90">
+        {/* 배경 원 */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          fill="transparent"
+          className="text-gray-200"
+        />
+        {/* 진행률 원 */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          fill="transparent"
+          strokeDasharray={strokeDasharray}
+          strokeDashoffset={strokeDashoffset}
+          strokeLinecap="round"
+          className={cn(
+            'transition-all duration-1000 ease-out',
+            status.level === 'critical'
+              ? 'text-negative'
+              : status.level === 'warning'
+                ? 'text-cautionary'
+                : status.level === 'good'
+                  ? 'text-positive'
+                  : 'text-brand-darkblue',
+          )}
+        />
+      </svg>
+
+      {/* 중앙 텍스트 */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="text-center">
+          <p className={cn('text-lg font-bold', status.color)}>{percentage.toFixed(1)}%</p>
+          <p className="text-xs text-gray-600">사용중</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const UsageAnalysisCard: React.FC<UsageAnalysisCardProps> = ({ data, className }) => {
+  const status = getUsageStatus(data.usage_percentage);
+  const StatusIcon = status.icon;
+
+  return (
+    <Card
+      className={cn(
+        'w-full max-w-sm bg-gradient-to-br from-blue-50 to-purple-50 border-blue-200 shadow-lg gap-2',
+        className,
+      )}
+    >
+      <CardHeader className="pt-2">
+        <CardTitle className="text-base font-bold text-brand-darkblue flex items-center gap-2">
+          <Smartphone className="w-4 h-4" />
+          사용량 분석
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent className="px-3 space-y-3">
+        {/* 현재 요금제 정보 */}
+        <div className="bg-white/80 backdrop-blur-sm rounded-lg p-3 border border-white/20">
+          <div className="flex justify-between items-center">
+            <div>
+              <p className="text-xs text-gray-600">현재 요금제</p>
+              <p className="text-base font-bold text-brand-darkblue">{data.current_plan}</p>
+            </div>
+            <div className="text-right">
+              <div className="flex items-center gap-1 text-gray-600">
+                <DollarSign className="w-3 h-3" />
+                <span className="text-xs">월 요금</span>
+              </div>
+              <p className="text-caption-1 font-bold text-brand-red">
+                {formatPrice(data.current_price)}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-white/80 backdrop-blur-sm rounded-lg p-3 border border-white/20">
+          <div className="flex items-center gap-2">
+            {/* 원형 차트 */}
+            <div className="flex-shrink-0">
+              <CircularProgress percentage={data.usage_percentage} />
+            </div>
+
+            {/* 상세 사용량 */}
+            <div className="flex-1 space-y-2">
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-sm font-medium text-gray-700 flex items-center gap-1">
+                  <Wifi className="w-3 h-3" />
+                  남은 사용량
+                </p>
+              </div>
+
+              <div className="space-y-1">
+                {/* 데이터 */}
+                <div className="flex items-center justify-between p-2 bg-blue-50 rounded">
+                  <div className="flex items-center gap-2">
+                    <Wifi className="w-3 h-3 text-blue-600" />
+                    <span className="text-xs font-medium text-blue-800">데이터</span>
+                  </div>
+                  <span className="text-xs font-bold text-blue-800">
+                    {formatDataUsage(data.remaining_data)}
+                  </span>
+                </div>
+
+                {/* 음성 */}
+                <div className="flex items-center justify-between p-2 bg-green-50 rounded">
+                  <div className="flex items-center gap-2">
+                    <Phone className="w-3 h-3 text-green-600" />
+                    <span className="text-xs font-medium text-green-800">음성</span>
+                  </div>
+                  <span className="text-xs font-bold text-green-800">
+                    {data.remaining_voice >= 999999 ? '무제한' : `${data.remaining_voice}분`}
+                  </span>
+                </div>
+
+                {/* 문자 */}
+                <div className="flex items-center justify-between p-2 bg-purple-50 rounded">
+                  <div className="flex items-center gap-2">
+                    <MessageSquare className="w-3 h-3 text-purple-600" />
+                    <span className="text-xs font-medium text-purple-800">SMS</span>
+                  </div>
+                  <span className="text-xs font-bold text-purple-800">
+                    {data.remaining_sms >= 999999 ? '무제한' : `${data.remaining_sms}건`}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 권장사항 */}
+        <div className={cn('rounded-lg p-2 border', status.bgColor, status.borderColor)}>
+          <div className="flex items-start gap-2">
+            <StatusIcon className={cn('w-3 h-3 mt-0.5 flex-shrink-0', status.color)} />
+            <p className={cn('text-xs font-medium', status.color)}>
+              {getRecommendation(data.usage_percentage)}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/hooks/useChatMutation.ts
+++ b/src/hooks/useChatMutation.ts
@@ -2,6 +2,13 @@ import { useMutation } from '@tanstack/react-query';
 import { sendChatMessageStreaming } from '@/apis/chat/chat';
 import { getLikesRecommendationStreaming } from '@/apis/chat/chatLikes';
 import { sendUBTIAnswerStreaming } from '@/apis/ubti/ubti';
+import { getUsageRecommendationStreaming } from '@/apis/chat/usage';
+import type { UsageRecommendationRequest } from '@/apis/chat/usage';
+
+interface UsageRecommendationMutationParams {
+  onChunk: (chunk: string) => void;
+  tone: 'muneoz' | 'general';
+}
 
 export const useChatMutation = () =>
   useMutation({
@@ -75,3 +82,18 @@ export const useUBTIMutation = () =>
       );
     },
   });
+
+export const useUsageRecommendationMutation = () => {
+  return useMutation({
+    mutationFn: async ({ onChunk, tone }: UsageRecommendationMutationParams) => {
+      const request: UsageRecommendationRequest = { tone };
+
+      await getUsageRecommendationStreaming(request, ({ data }) => {
+        onChunk(data);
+      });
+    },
+    onError: (error) => {
+      console.error('Usage recommendation mutation error:', error);
+    },
+  });
+};

--- a/src/lib/streaming/index.ts
+++ b/src/lib/streaming/index.ts
@@ -5,6 +5,8 @@ export type {
   LikesRecommendationChunk,
   SendUBTIRequest,
   UBTIChunk,
+  UsageRecommendationRequest,
+  UsageRecommendationChunk,
   StreamingConfig,
   StreamingStats,
 } from './types';

--- a/src/lib/streaming/types.ts
+++ b/src/lib/streaming/types.ts
@@ -28,6 +28,15 @@ export interface UBTIChunk {
   data: string;
 }
 
+// 사용량 기반 추천 타입
+export interface UsageRecommendationRequest {
+  tone: 'muneoz' | 'general';
+}
+
+export interface UsageRecommendationChunk {
+  data: string;
+}
+
 // 스트리밍 설정 인터페이스
 export interface StreamingConfig {
   minDelay: number;

--- a/src/pages/chatbot/ChatBubble.tsx
+++ b/src/pages/chatbot/ChatBubble.tsx
@@ -6,6 +6,7 @@ import { Message } from '@/types/chat';
 import { PlanRecommendation } from '@/types/streaming';
 import { AvatarComponent } from '@/components/Avatar';
 import { SubscriptionCard } from '@/components/SubscriptionCard/SubscriptionCard';
+import { UsageAnalysisCard } from '@/components/UsageAnalysisCard/UsageAnalysisCard';
 import { cn } from '@/lib/utils';
 import { IMAGES } from '@/constant/imagePath';
 import { useNavigate } from 'react-router-dom';
@@ -138,6 +139,12 @@ const ChatBubble: React.FC<ChatBubbleProps> = React.memo(
       isLatestBotMessage,
       message.id,
     ]);
+
+    const shouldShowUsageAnalysisCard = React.useMemo(() => {
+      const hasUsageAnalysis = !!message.usageAnalysis;
+      const shouldShow = isRecommendationMessage || isLatestBotMessage || hasUsageAnalysis;
+      return isBot && hasUsageAnalysis && shouldShow;
+    }, [isBot, message.usageAnalysis, isRecommendationMessage, isLatestBotMessage]);
 
     // 타임스탬프 포맷팅 최적화
     const formatTimestamp = React.useMemo(() => {
@@ -316,6 +323,13 @@ const ChatBubble: React.FC<ChatBubbleProps> = React.memo(
                 onBrandSelect={handleBrandSelect}
                 className="max-w-sm"
               />
+            </div>
+          )}
+
+          {/* 사용량 분석 카드 */}
+          {shouldShowUsageAnalysisCard && message.usageAnalysis && (
+            <div key={`usage-analysis-${uniqueMessageKey}`}>
+              <UsageAnalysisCard data={message.usageAnalysis} className="max-w-sm" />
             </div>
           )}
         </div>

--- a/src/pages/chatbot/ChatContainer/PremiumFeatureButton.tsx
+++ b/src/pages/chatbot/ChatContainer/PremiumFeatureButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button } from '@/components/Button';
 import { Lock } from 'lucide-react';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { cn } from '@/lib/utils';
 
 interface PremiumFeatureButtonProps {
   children: React.ReactNode;
@@ -23,26 +24,26 @@ export const PremiumFeatureButton: React.FC<PremiumFeatureButtonProps> = ({
   const { isLoggedIn } = useAuthStore();
 
   const handleClick = () => {
-    if (!isLoggedIn) {
-      return;
-    }
+    if (!isLoggedIn) return;
     onClick();
   };
 
   const isDisabled = disabled || !isLoggedIn;
 
   return (
-    <>
-      <Button
-        variant={variant}
-        className={`${className} ${!isLoggedIn ? 'opacity-70' : ''}`}
-        onClick={handleClick}
-        disabled={isDisabled}
-        title={!isLoggedIn ? `${featureName}은 로그인이 필요한 기능입니다` : undefined}
-      >
-        {!isLoggedIn && <Lock className="w-4 h-4 mr-1" />}
-        {children}
-      </Button>
-    </>
+    <Button
+      variant={variant}
+      className={cn(
+        'flex-1 h-10 px-2 text-sm leading-none flex items-center justify-center gap-0 whitespace-nowrap overflow-hidden',
+        className,
+        !isLoggedIn && 'opacity-70',
+      )}
+      onClick={handleClick}
+      disabled={isDisabled}
+      title={!isLoggedIn ? `${featureName}은 로그인이 필요한 기능입니다` : undefined}
+    >
+      {!isLoggedIn && <Lock className="w-4 h-4 mr-1" />}
+      {children}
+    </Button>
   );
 };

--- a/src/pages/chatbot/ChatInputArea/ChatInputArea.tsx
+++ b/src/pages/chatbot/ChatInputArea/ChatInputArea.tsx
@@ -12,6 +12,7 @@ interface ChatInputAreaProps {
   onSendMessage: (message: string) => void;
   onUBTIStart: () => void;
   onLikesRecommendation: () => void;
+  onUsageRecommendation: () => void;
   onResetChat: () => void;
 }
 
@@ -23,6 +24,7 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
   onSendMessage,
   onUBTIStart,
   onLikesRecommendation,
+  onUsageRecommendation,
   onResetChat,
 }) => {
   return (
@@ -36,7 +38,15 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
             disabled={buttonDisabled}
             featureName="UBTI 분석"
           >
-            타코시그널 검사하기
+            🐙 타코시그널
+          </PremiumFeatureButton>
+          <PremiumFeatureButton
+            className="flex-1"
+            onClick={onUsageRecommendation}
+            disabled={buttonDisabled}
+            featureName="사용량 분석"
+          >
+            📊 사용량
           </PremiumFeatureButton>
           <PremiumFeatureButton
             className="flex-1"
@@ -44,7 +54,7 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
             disabled={buttonDisabled}
             featureName="서비스 추천"
           >
-            브랜드 케미 분석
+            💜 취향저격
           </PremiumFeatureButton>
         </div>
       )}

--- a/src/stores/useChatStore.ts
+++ b/src/stores/useChatStore.ts
@@ -90,11 +90,13 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
   },
 
   // 카드 정보도 함께 업데이트
+  // 카드 정보와 사용량 분석도 함께 업데이트
   updateLastBotMessageWithCards: (
     sessionId,
     content,
     planRecommendations,
     subscriptionRecommendations,
+    usageAnalysis,
   ) => {
     set((state) => {
       const session = state.sessions[sessionId];
@@ -112,6 +114,7 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
             timestamp: new Date(),
             planRecommendations,
             subscriptionRecommendations,
+            usageAnalysis, // 👈 추가
           };
           updated = true;
           break;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,15 +1,18 @@
-import { PlanRecommendation, SubscriptionRecommendationsData } from './streaming';
+import {
+  PlanRecommendation,
+  SubscriptionRecommendationsData,
+  UsageAnalysisData,
+} from './streaming';
 
 export interface Message {
   id: string;
   content: string;
   type: 'user' | 'bot';
   timestamp: Date;
-  // 카드 정보
-  planRecommendations?: PlanRecommendation[];
-  subscriptionRecommendations?: SubscriptionRecommendationsData;
-  // 추천 메시지인지 여부
-  isRecommendationMessage?: boolean;
+  planRecommendations?: PlanRecommendation[]; // 요금제 카드
+  subscriptionRecommendations?: SubscriptionRecommendationsData; // 구독 카드
+  usageAnalysis?: UsageAnalysisData; // 사용량 분석
+  isRecommendationMessage?: boolean; // 추천 메시지인지 여부
 }
 
 export interface ChatSession {
@@ -50,6 +53,7 @@ export interface ChatActions {
     content: string,
     planRecommendations?: PlanRecommendation[],
     subscriptionRecommendations?: SubscriptionRecommendationsData,
+    usageAnalysis?: UsageAnalysisData,
   ) => void;
 
   addPlanRecommendationsToMessage: (

--- a/src/types/streaming.ts
+++ b/src/types/streaming.ts
@@ -100,6 +100,22 @@ interface UBTIStreamingQuestionsComplete {
   type: 'questions_complete';
 }
 
+// 사용량 분석 관련 타입
+export interface UsageAnalysisData {
+  user_id: number;
+  current_plan: string;
+  current_price: number;
+  remaining_data: number;
+  remaining_voice: number;
+  remaining_sms: number;
+  usage_percentage: number;
+}
+
+export interface UsageAnalysisResponse {
+  type: 'usage_analysis';
+  data: UsageAnalysisData;
+}
+
 export type UBTIStreamingMessage =
   | UBTIStreamingQuestionStart
   | UBTIStreamingQuestion
@@ -110,6 +126,7 @@ export type UBTIStreamingMessage =
 export type StreamingResponse =
   | PlanRecommendationsResponse
   | SubscriptionRecommendationsResponse
+  | UsageAnalysisResponse
   | MessageStartResponse
   | MessageChunkResponse
   | MessageEndResponse


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #145 

### 🔎 작업 내용

- [x] `UsageAnalysisCard` UI 컴포넌트 제작
  - [x] 사용률에 따른 상태/아이콘/색상 분기 처리
  - [x] 원형 퍼센트 차트(`CircularProgress`) 구현
  - [x] 요금제 정보 및 남은 데이터/음성/SMS 표시
- [x] 채팅 API 응답 데이터 연동 (`UsageAnalysisData`)

### 📸 스크린샷
![ezgif-40dd03dd5902a8](https://github.com/user-attachments/assets/e6706a2b-4fff-471e-8391-323d2f71e614)

### :loudspeaker: 전달사항
> @eunchrri 은채언니가 작업한 스와이퍼 컴포넌트에서 요금제 카드가 하나이면 하단 패딩 없도록 리팩토링했는데 확인해주세용!
- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
