### PR TITLE
Feat: [EVER-229] coupon 컴포넌트 제작

### DIFF
--- a/src/components/Coupon/Coupon.stories.tsx
+++ b/src/components/Coupon/Coupon.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Coupon } from './Coupon';
+
+const meta: Meta<typeof Coupon> = {
+  title: 'Components/Coupon',
+  component: Coupon,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Coupon>;
+
+export const Owned: Story = {
+  args: {
+    type: 'owned',
+    brandName: '배스킨라빈스',
+    description: '파인트 4천원 할인',
+    dateRange: '2025.06.01 ~ 2025.06.30',
+    imageUrl: '/images/moonoz-hello.png',
+  },
+};
+
+export const Liked: Story = {
+  args: {
+    type: 'liked',
+    brandName: '스타벅스',
+    description: '아메리카노 할인권',
+    dateRange: '2025.06.01 ~ 2025.06.30',
+    imageUrl: '/images/moonoz-hello.png',
+  },
+};
+
+export const HotUrgent: Story = {
+  args: {
+    type: 'hot',
+    brandName: '롯데렌터카',
+    description: '45% 할인 쿠폰',
+    dateRange: '2025.06.01 ~ 2025.06.30',
+    imageUrl: '/images/moonoz-hello.png',
+    isUrgent: true,
+  },
+};

--- a/src/components/Coupon/Coupon.tsx
+++ b/src/components/Coupon/Coupon.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Download, Heart } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { CouponProps } from './Coupon.types';
+import { couponVariants } from './couponVariants';
+
+export const Coupon: React.FC<CouponProps> = ({
+  type,
+  brandName,
+  description,
+  dateRange,
+  imageUrl,
+}) => {
+  const isOwned = type === 'owned';
+  const isLiked = type === 'liked';
+  const isHot = type === 'hot';
+
+  const styleType = isHot ? 'hotUrgent' : type;
+
+  return (
+    <div className="relative flex w-full max-w-md overflow-hidden border border-gray-200 rounded-[1rem] bg-white">
+      <div className="flex-1 px-4 py-3 relative bg-white rounded-l-[1rem]">
+        <div className="flex items-center gap-2">
+          {imageUrl && (
+            <img
+              src={imageUrl}
+              alt={`${brandName} 로고`}
+              className="w-10 h-10 mr-3 object-contain rounded-full"
+            />
+          )}
+          <div>
+            <p className="subtitle-1">{brandName}</p>
+            <p className="body-2 text-gray-600">{description}</p>
+            <p className="caption-2 text-muted-foreground">{dateRange}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="relative w-4 bg-transparent">
+        <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-px border-l border-dashed border-gray-300" />
+        <div className="absolute top-0 left-0 w-4 h-4 rounded-bl-full bg-white" />
+        <div className="absolute bottom-0 left-0 w-4 h-4 rounded-tl-full bg-white" />
+      </div>
+
+      <div className="relative w-20">
+        {[...Array(6)].map((_, i) => (
+          <div
+            key={i}
+            className="absolute w-2 h-2 rounded-full bg-white left-0"
+            style={{
+              top: `${i * 14 + 8}px`,
+              transform: 'translateX(-50%)',
+            }}
+          />
+        ))}
+
+        <div
+          className={cn(
+            'h-full w-full flex flex-col items-center justify-center px-1 text-white text-center whitespace-pre',
+            couponVariants({ type: styleType }),
+          )}
+        >
+          {isOwned && <span className="caption-2">발급 완료</span>}
+
+          {isHot && (
+            <>
+              <span className="caption-2">쿠폰 받기</span>
+              <Download className="w-4 h-4 mt-1" />
+            </>
+          )}
+
+          {isLiked && <Heart className="w-4.5 h-4.5 text-white" />}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Coupon/Coupon.types.ts
+++ b/src/components/Coupon/Coupon.types.ts
@@ -1,0 +1,8 @@
+export interface CouponProps {
+  type: 'owned' | 'liked' | 'hot';
+  brandName: string;
+  description: string;
+  dateRange: string;
+  imageUrl?: string;
+  isUrgent?: boolean;
+}

--- a/src/components/Coupon/couponVariants.ts
+++ b/src/components/Coupon/couponVariants.ts
@@ -1,0 +1,18 @@
+import { cva } from 'class-variance-authority';
+
+export const couponVariants = cva(
+  'w-20 flex flex-col items-center justify-center px-1 text-sm text-white text-center whitespace-pre',
+  {
+    variants: {
+      type: {
+        owned: 'bg-[#c0c0c0]',
+        hot: 'bg-[#5ebcbc]',
+        hotUrgent: 'bg-[#5ebcbc]',
+        liked: 'bg-pink-400',
+      },
+    },
+    defaultVariants: {
+      type: 'owned',
+    },
+  },
+);

--- a/src/components/Coupon/index.ts
+++ b/src/components/Coupon/index.ts
@@ -1,0 +1,2 @@
+export * from './Coupon';
+export * from './Coupon.types';

--- a/src/components/ui/coupon.tsx
+++ b/src/components/ui/coupon.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export const CouponFrame = ({
+  children,
+  isUrgent = false,
+  className,
+}: {
+  children: React.ReactNode;
+  isUrgent?: boolean;
+  className?: string;
+}) => {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between gap-4 rounded-xl border p-4 shadow-sm transition-all',
+        isUrgent && 'border-destructive',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #147 

### 🔎 작업 내용

- [x] 쿠폰 UI 전체 구조 구현 (왼쪽 본문 / 절취선 / 상태 박스)
- [x] 실제 티켓 느낌을 위한 톱니형 절단 디자인 적용
- [x] 텍스트 스타일 팀 공통 유틸리티 적용
- [x] `couponVariants`를 통한 타입별 스타일 관리

### 📸 스크린샷
- storybook 확인 
<img width="296" alt="image" src="https://github.com/user-attachments/assets/e60ef034-0ff6-4988-9831-6883220dc356" />

### :loudspeaker: 전달사항
- 추가 변경하고 싶은 사항 있으면 알려주세요~!

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
