### PR TITLE
Feat: [EVER-239] 로딩중 페이지 돌아가는 무너 추가

### DIFF
--- a/src/pages/common/Empty.tsx
+++ b/src/pages/common/Empty.tsx
@@ -9,6 +9,7 @@ interface EmptyProps {
   buttonText?: string;
   buttonLink?: string;
   className?: string;
+  onClickButton?: () => void;
 }
 
 const Empty: React.FC<EmptyProps> = ({
@@ -18,6 +19,7 @@ const Empty: React.FC<EmptyProps> = ({
   buttonText,
   buttonLink,
   className = '',
+  onClickButton,
 }) => {
   const navigate = useNavigate();
 
@@ -26,12 +28,18 @@ const Empty: React.FC<EmptyProps> = ({
       <img src={imageSrc} alt={altText} className="w-40 h-auto mb-4" />
       <p className="text-gray-500 text-sm text-center mb-4">{message}</p>
 
-      {buttonText && buttonLink && (
+      {buttonText && (
         <Button
           variant="outline"
           size="default"
           className="bg-white/50 border-black/50 text-gray-800 hover:bg-white/70"
-          onClick={() => navigate(buttonLink)}
+          onClick={() => {
+            if (onClickButton) {
+              onClickButton();
+            } else if (buttonLink) {
+              navigate(buttonLink);
+            }
+          }}
         >
           {buttonText}
         </Button>

--- a/src/pages/common/LoadingMooner.tsx
+++ b/src/pages/common/LoadingMooner.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { IMAGES } from '@/constant/imagePath';
+
+const loadingSteps = [
+  { imageUrl: IMAGES.MOONER.rotation_1, title: '로딩 중...' },
+  { imageUrl: IMAGES.MOONER.rotation_2, title: '잠시만 기다려주세요' },
+  { imageUrl: IMAGES.MOONER.rotation_3, title: '데이터 불러오는 중...' },
+  { imageUrl: IMAGES.MOONER.rotation_4, title: '조금만 기다려주세요!' },
+];
+
+interface LoadingMoonerProps {
+  animated?: boolean;
+}
+
+const LoadingMooner: React.FC<LoadingMoonerProps> = ({ animated = true }) => {
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    if (!animated) return;
+
+    const interval = setInterval(() => {
+      setStep((prev) => (prev + 1) % loadingSteps.length);
+    }, 250);
+    return () => clearInterval(interval);
+  }, [animated]);
+
+  const current = loadingSteps[step];
+
+  return (
+    <div className="flex flex-col items-center justify-center py-10">
+      <img
+        src={animated ? current.imageUrl : IMAGES.MOONER['rotation_1']}
+        alt={current.title}
+        className="w-50 h-auto"
+      />
+      <p className="mt-4 text-m text-gray-600">{current.title}</p>
+    </div>
+  );
+};
+
+export default LoadingMooner;

--- a/src/pages/hotplace/HotPlace.tsx
+++ b/src/pages/hotplace/HotPlace.tsx
@@ -7,21 +7,30 @@ import StoreMap from './StoreMap/StoreMap';
 import { Card, CardContent } from '@/components/Card';
 import { MapPin, Store, TrendingUp } from 'lucide-react';
 import { IMAGES } from '@/constant/imagePath';
+import LoadingMooner from '@/pages/common/LoadingMooner';
 
 const HotPlace = () => {
   const [bestDeals, setBestDeals] = useState<TopCoupon[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [option, setOption] = useState<'popup' | 'store'>('popup');
-
-  const allBrandIds = [1, 2, 3, 4, 5, 6, 7, 8];
-
+  const [mapLoading, setMapLoading] = useState(true);
+  const [showMapLoader, setShowMapLoader] = useState(false);
   const [searchParams] = useSearchParams();
   const subscribedBrandIdsParam = searchParams.get('subscribedBrandIds');
   const subscribedBrandIds = subscribedBrandIdsParam
     ? subscribedBrandIdsParam.split(',').map((id) => Number(id))
     : [1, 3, 4];
-
   const selectedBrandIds: number[] = subscribedBrandIds;
+  const allBrandIds = [1, 2, 3, 4, 5, 6, 7, 8];
+
+  useEffect(() => {
+    if (mapLoading) {
+      const timer = setTimeout(() => setShowMapLoader(true), 2000);
+      return () => clearTimeout(timer);
+    } else {
+      setShowMapLoader(false);
+    }
+  }, [mapLoading]);
 
   useEffect(() => {
     const fetchCoupons = async () => {
@@ -38,8 +47,13 @@ const HotPlace = () => {
   }, []);
 
   useEffect(() => {
-    console.log('selectedBrandIds:', selectedBrandIds);
-  }, [subscribedBrandIds]);
+    if (mapLoading) {
+      const timer = setTimeout(() => setShowMapLoader(true), 2000);
+      return () => clearTimeout(timer);
+    } else {
+      setShowMapLoader(false);
+    }
+  }, [mapLoading]);
 
   const getDiscountLabel = (deal: TopCoupon) => {
     if (!deal) return '';
@@ -110,10 +124,18 @@ const HotPlace = () => {
       <div className="px-4">
         <Card>
           <CardContent className="p-0">
-            {option === 'popup' ? (
-              <PopupMap />
+            {showMapLoader ? (
+              <div className="h-[400px] flex items-center justify-center">
+                <LoadingMooner />
+              </div>
+            ) : option === 'popup' ? (
+              <PopupMap onLoadingChange={setMapLoading} />
             ) : (
-              <StoreMap allBrandIds={allBrandIds} selectedIds={selectedBrandIds} />
+              <StoreMap
+                allBrandIds={allBrandIds}
+                selectedIds={selectedBrandIds}
+                onLoadingChange={setMapLoading}
+              />
             )}
           </CardContent>
         </Card>

--- a/src/pages/hotplace/PopupMap/PopupMap.tsx
+++ b/src/pages/hotplace/PopupMap/PopupMap.tsx
@@ -7,12 +7,14 @@ import MapLegend from './MapLegend';
 import MapPopover from './MapPopover';
 import { createMarkerClustering, type MarkerClusteringInstance } from '@/utils/markerClustering';
 import { useState, useRef, useEffect, useCallback } from 'react';
+import LoadingMooner from '@/pages/common/LoadingMooner';
 
 interface PopupMapProps {
   className?: string;
   style?: React.CSSProperties;
   radius?: number;
   initialOpenPopupId?: number;
+  onLoadingChange?: (loading: boolean) => void;
 }
 
 interface PopupData {
@@ -29,6 +31,7 @@ export default function PopupMap({
   style = {},
   radius = 5,
   initialOpenPopupId,
+  onLoadingChange,
 }: PopupMapProps) {
   const [allPopups, setAllPopups] = useState<GetPopupListResponse | null>(null);
   const [nearbyPopups, setNearbyPopups] = useState<GetNearbyPopupListResponse | null>(null);
@@ -68,6 +71,7 @@ export default function PopupMap({
 
   // 전체 팝업 데이터 로드
   useEffect(() => {
+    onLoadingChange?.(true);
     const fetchAllPopups = async () => {
       try {
         setLoading(true);
@@ -81,6 +85,7 @@ export default function PopupMap({
         setError('네트워크 오류가 발생했습니다.');
       } finally {
         setLoading(false);
+        onLoadingChange?.(false);
       }
     };
     fetchAllPopups();
@@ -404,14 +409,8 @@ export default function PopupMap({
 
   if (loading) {
     return (
-      <div
-        className={`flex items-center justify-center ${className}`}
-        style={{ width: '100%', height: '400px', ...style }}
-      >
-        <div className="flex items-center gap-2 text-gray-500 text-sm">
-          <div className="w-4 h-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin"></div>
-          지도를 불러오는 중...
-        </div>
+      <div className="flex items-center justify-center h-[400px]">
+        <LoadingMooner />
       </div>
     );
   }

--- a/src/pages/hotplace/StoreMap/StoreMap.tsx
+++ b/src/pages/hotplace/StoreMap/StoreMap.tsx
@@ -6,12 +6,14 @@ import MapLegend from './MapLegend';
 import MapPopover from './MapPopover';
 import { createMarkerClustering, type MarkerClusteringInstance } from '@/utils/markerClustering';
 import { useState, useRef, useEffect, useCallback } from 'react';
+import LoadingMooner from '@/pages/common/LoadingMooner';
 
 interface StoreMapProps {
   className?: string;
   style?: React.CSSProperties;
   allBrandIds: number[];
   selectedIds: number[];
+  onLoadingChange?: (loading: boolean) => void;
 }
 
 interface StoreData {
@@ -27,6 +29,7 @@ export default function StoreMap({
   style = {},
   selectedIds,
   allBrandIds,
+  onLoadingChange,
 }: StoreMapProps) {
   const [selectedBrandIds, setSelectedBrandIds] = useState<number[]>([]);
 
@@ -74,7 +77,7 @@ export default function StoreMap({
       try {
         setLoading(true);
         setError(null);
-
+        onLoadingChange?.(true);
         if (!currentLocation) {
           setError('현재 위치 정보가 없습니다.');
           setLoading(false);
@@ -109,6 +112,7 @@ export default function StoreMap({
         setError('매장 조회 중 오류가 발생했습니다.');
       } finally {
         setLoading(false);
+        onLoadingChange?.(false);
       }
     };
 
@@ -314,14 +318,8 @@ export default function StoreMap({
 
   if (loading) {
     return (
-      <div
-        className={`flex items-center justify-center ${className}`}
-        style={{ width: '100%', height: '400px', ...style }}
-      >
-        <div className="flex items-center gap-2 text-gray-500 text-sm">
-          <div className="w-4 h-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin"></div>
-          지도를 불러오는 중...
-        </div>
+      <div className="flex items-center justify-center h-[400px]">
+        <LoadingMooner />
       </div>
     );
   }

--- a/src/pages/me/MyPage.tsx
+++ b/src/pages/me/MyPage.tsx
@@ -1,5 +1,5 @@
 import { BillSummaryCard } from '@/components/ui/billsummarycard';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent } from '@/components/Card';
 import { useQuery } from '@tanstack/react-query';
 import { fetchCurrentPlan } from '@/apis/plan/getCurrentPlan';
@@ -8,6 +8,7 @@ import { Ticket, Coins, Package, FolderHeart, Stamp, ClipboardCheck } from 'luci
 import { Link } from 'react-router-dom';
 import { IMAGES } from '@/constant/imagePath';
 import { fetchUserCoupons } from '@/apis/coupon/getUserCoupons';
+import LoadingMooner from '@/pages/common/LoadingMooner';
 
 const MyPage: React.FC = () => {
   const {
@@ -28,7 +29,18 @@ const MyPage: React.FC = () => {
   });
   const availableCoupons = coupons.filter((c) => c.isUsed === false);
 
-  if (isLoading) return <p className="p-4">로딩 중...</p>;
+  const [shouldShowLoading, setShouldShowLoading] = useState(false);
+
+  useEffect(() => {
+    if (isLoading) {
+      const timer = setTimeout(() => setShouldShowLoading(true), 2000);
+      return () => clearTimeout(timer);
+    } else {
+      setShouldShowLoading(false);
+    }
+  }, [isLoading]);
+
+  if (isLoading && shouldShowLoading) return <LoadingMooner />;
   if (error || !plan) return <p className="p-4">요금제를 불러오지 못했습니다.</p>;
 
   const formatUsage = (

--- a/src/pages/me/subscriptions/Subscriptions.tsx
+++ b/src/pages/me/subscriptions/Subscriptions.tsx
@@ -6,6 +6,8 @@ import { Card, CardContent } from '@/components/Card';
 import { Package } from 'lucide-react';
 import { formatPrice } from '@/utils/priceUtils';
 import LoadingMooner from '@/pages/common/LoadingMooner';
+import Empty from '@/pages/common/Empty';
+import { IMAGES } from '@/constant/imagePath';
 
 const Subscriptions: React.FC = () => {
   const { data: userSubscriptions = [], isLoading: loadingUser } = useQuery({
@@ -49,7 +51,13 @@ const Subscriptions: React.FC = () => {
         <div className="text-xl mb-6">구독상품 목록</div>
       </div>
       {merged.length === 0 ? (
-        <p className="text-sm text-gray-500">구독 중인 상품이 없습니다.</p>
+        <Empty
+          imageSrc={IMAGES.MOONER['mooner-sad']}
+          altText="슬픈 무너"
+          message="현재 보유한 구독상품이 없어요"
+          buttonText="구독상품 PICK 하러가기"
+          buttonLink="/home"
+        />
       ) : (
         <div className="grid grid-cols-2 gap-4 w-full">
           {merged.map((sub) => (

--- a/src/pages/me/subscriptions/Subscriptions.tsx
+++ b/src/pages/me/subscriptions/Subscriptions.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchUserSubscriptions } from '@/apis/subscription/getUserSubscriptions';
 import { getMainSubscriptions } from '@/apis/subscription/getMainSubscriptions';
 import { Card, CardContent } from '@/components/Card';
 import { Package } from 'lucide-react';
 import { formatPrice } from '@/utils/priceUtils';
+import LoadingMooner from '@/pages/common/LoadingMooner';
 
 const Subscriptions: React.FC = () => {
   const { data: userSubscriptions = [], isLoading: loadingUser } = useQuery({
@@ -19,8 +20,20 @@ const Subscriptions: React.FC = () => {
 
   const mainSubscriptions = mainRes?.data ?? [];
 
-  if (loadingUser || loadingMain) return <p className="p-4">로딩 중...</p>;
+  const [shouldShowLoading, setShouldShowLoading] = useState(false);
 
+  useEffect(() => {
+    if (loadingUser || loadingMain) {
+      const timer = setTimeout(() => setShouldShowLoading(true), 2000);
+      return () => clearTimeout(timer);
+    } else {
+      setShouldShowLoading(false);
+    }
+  }, [loadingUser, loadingMain]);
+
+  if ((loadingUser || loadingMain) && shouldShowLoading) {
+    return <LoadingMooner />;
+  }
   const merged = userSubscriptions.map((sub) => {
     const matched = mainSubscriptions.find((m) => m.title === sub.main_title);
     return {
@@ -46,7 +59,7 @@ const Subscriptions: React.FC = () => {
                   <img
                     src={sub.image_url}
                     alt={sub.main_title}
-                    className="w-30 h-30 object-contain mx-auto mb-2"
+                    className="w-32 h-32 object-contain mx-auto"
                   />
                 )}
                 <h3 className="font-medium text-sm mb-1">{sub.main_title.split('+')[0].trim()}</h3>{' '}

--- a/src/pages/upltuple/UplTuple.tsx
+++ b/src/pages/upltuple/UplTuple.tsx
@@ -1,7 +1,5 @@
-// ✅ UplTuple.tsx - 페이지 구성만 담당
 import { UplusCalendar } from './Uplus/UplusCalendar';
 import { UplusBenefitPreview } from './Uplus/UplusBenefitPreview';
-// import { UplusBenefitDetail } from './Uplus/UplusBenefitDetail';
 
 const UplTuple = () => {
   return (
@@ -9,7 +7,6 @@ const UplTuple = () => {
       <h1 className="text-xl font-bold text-brand-darkblue mb-4">유플투쁠 혜택 캘린더</h1>
       <UplusCalendar />
       <UplusBenefitPreview />
-      {/* <UplusBenefitDetail /> */}
     </div>
   );
 };

--- a/src/pages/upltuple/Uplus/UplusBenefitDetail.tsx
+++ b/src/pages/upltuple/Uplus/UplusBenefitDetail.tsx
@@ -13,6 +13,9 @@ import { BenefitDetail } from '@/types/uplus';
 import { getCategoryEmoji } from '@/utils/emoji/getCategoryEmoji';
 import { formatDateWithDay } from '@/utils/format/formatDateWithDay';
 import { getDday } from '@/utils/format/getDday';
+import Empty from '@/pages/common/Empty';
+import { IMAGES } from '@/constant/imagePath';
+import { useNavigate } from 'react-router-dom';
 
 interface BenefitDetailModalProps {
   isOpen: boolean;
@@ -24,6 +27,7 @@ export const BenefitDetailModal = ({ isOpen, onClose, selectedDate }: BenefitDet
   const [benefits, setBenefits] = useState<BenefitDetail[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (isOpen && selectedDate) {
@@ -79,10 +83,13 @@ export const BenefitDetailModal = ({ isOpen, onClose, selectedDate }: BenefitDet
           )}
 
           {benefits && benefits.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-8 text-gray-500">
-              <div className="text-4xl mb-2">😔</div>
-              <div>이 날짜에는 혜택이 없습니다</div>
-            </div>
+            <Empty
+              imageSrc={IMAGES.MOONER['mooner-sad']}
+              altText="슬픈 무너"
+              message="이 날짜에는 제공되는 혜택이 없어요."
+              buttonText="닫기"
+              onClickButton={() => navigate(-1)}
+            />
           )}
 
           {benefits && benefits.length > 0 && (

--- a/src/pages/upltuple/Uplus/UplusBenefitPreview.tsx
+++ b/src/pages/upltuple/Uplus/UplusBenefitPreview.tsx
@@ -8,24 +8,24 @@ import 'swiper/css/free-mode';
 import 'swiper/css/pagination';
 import { getBrandBackgroundColor } from '@/utils/brandColor';
 import { getDday } from '@/utils/format/getDday';
-
-export const UplusBenefitPreview = () => {
-  const [benefits, setBenefits] = useState<Benefit[] | null>(null);
+interface UplusBenefitPreviewProps {
+  onLoadComplete?: () => void;
+}
+export const UplusBenefitPreview = ({ onLoadComplete }: UplusBenefitPreviewProps) => {
+  const [benefits, setBenefits] = useState<Benefit[]>([]);
   const [showTooltip, setShowTooltip] = useState(false); // ✅ 툴팁 표시 상태
 
   useEffect(() => {
     getMonthlyBenefits()
       .then((data) => {
         setBenefits(data);
+        onLoadComplete?.();
       })
       .catch((err) => {
         console.error('❌ 유플 혜택 조회 실패:', err);
+        onLoadComplete?.();
       });
-  }, []);
-
-  if (benefits === null) {
-    return <p className="text-sm text-gray-400 px-2">혜택을 불러오는 중입니다...</p>;
-  }
+  }, [onLoadComplete]);
 
   return (
     <div

--- a/src/pages/upltuple/Uplus/UplusCalendar.tsx
+++ b/src/pages/upltuple/Uplus/UplusCalendar.tsx
@@ -5,8 +5,10 @@ import { getMonthlyBenefits } from '@/apis/uplus/benefit';
 import { Benefit } from '@/types/uplus';
 import { getBrandDotColor } from '@/utils/brandColor';
 import { BenefitDetailModal } from './UplusBenefitDetail';
-
-export const UplusCalendar = () => {
+interface UplusCalendarProps {
+  onLoadComplete?: () => void;
+}
+export const UplusCalendar = ({ onLoadComplete }: UplusCalendarProps) => {
   const [benefits, setBenefits] = useState<Benefit[] | null>(null);
   const [month, setMonth] = useState(new Date());
 
@@ -18,11 +20,13 @@ export const UplusCalendar = () => {
       .then((data) => {
         console.log('✅ 응답 성공:', data);
         setBenefits(data);
+        onLoadComplete?.();
       })
       .catch((err) => {
         console.error('❌ 유플 혜택 조회 실패:', err.response?.data || err.message);
+        onLoadComplete?.();
       });
-  }, []);
+  }, [onLoadComplete]);
 
   // 날짜 클릭 핸들러 추가!
   const handleDateClick = (date: Date, isCurrentMonth: boolean) => {
@@ -32,8 +36,8 @@ export const UplusCalendar = () => {
     setIsModalOpen(true);
   };
 
-  if (!benefits) {
-    return <p className="text-sm text-gray-400">혜택 불러오는 중...</p>;
+  if (!benefits || benefits.length === 0) {
+    return null;
   }
 
   return (


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->


### 🔎 작업 내용

1. 전체 페이지 로딩에 LoadingMooner 적용 (로딩 UX 통일)
  - 마이페이지, 핫플레이스, 구독페이지 등
  - 조건: 2초 이상 걸릴 경우 회전 무너 노출

2. Empty 컴포넌트를 활용한 NoData 처리 적용
  - 혜택 상세 모달 (BenefitDetailModal)
  - 구독 상품 없음 페이지 (Subscriptions)

3. Empty 컴포넌트에 onClickButton prop 추가
  - 닫기 버튼 클릭 시 모달 닫기 or 뒤로가기 가능
  - 버튼이 buttonLink 없이도 렌더링 되도록 조건 수정

4. 코드 리팩토링: 불필요한 조건 제거 및 유연한 UI 분기

### 📸 스크린샷
- **로딩 페이지**
- 핫플 (원래 페이지 전체에 돌아가는 무너 넣으려다가 사용자 입장에서 너무 느리다고 판단할 것 같아서 지도 부분에만 추가, 나머지는 바로 렌더링 되도록)
![20250622-0749-18 0580718](https://github.com/user-attachments/assets/144210d5-d99b-4603-87ea-4ed88426feb8)


- 유플투쁠 캘린더 들어갈 때 
![20250622-0804-36 3502534](https://github.com/user-attachments/assets/7bd4ce46-74fc-488d-8a83-611e901becd3)



- **NoData 페이지**
- 캘린더> 혜택 없는 날
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/5868f4c6-e060-4b6b-b9c3-cd95c0a5feb7" width="300" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/3db28374-a540-46c3-acf2-8c26791c0384" width="300" />
    </td>
  </tr>
</table>





- 구독 상품 없는 날
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/62af538e-0067-4211-b76e-4779bedc6070" width="300" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/59919526-bf6c-4d8e-a6a0-724607654ade" width="300" />
    </td>
  </tr>
</table>

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
