### PR TITLE
Refactor: [EVER-232] 회원가입 캘린더 날짜 오류 수정

### DIFF
--- a/src/pages/auth/Signup.tsx
+++ b/src/pages/auth/Signup.tsx
@@ -179,16 +179,22 @@ const Signup: React.FC = () => {
             </div>
 
             {/* Birth Date */}
-            <div className="space-y-2">
-              <Calendar28
-                value={formData.birthDate ? new Date(formData.birthDate) : null}
-                onChange={(date) => {
-                  handleInputChange('birthDate', date ? date.toISOString().substring(0, 10) : '');
-                }}
-                label="생년월일"
-                placeholder="YYYY-MM-DD"
-              />
-            </div>
+            <Calendar28
+              value={formData.birthDate ? new Date(formData.birthDate) : null}
+              onChange={(date) => {
+                if (date) {
+                  const timezoneOffset = date.getTimezoneOffset() * 60000;
+                  const localDate = new Date(date.getTime() - timezoneOffset)
+                    .toISOString()
+                    .substring(0, 10); // YYYY-MM-DD 형식
+                  handleInputChange('birthDate', localDate);
+                } else {
+                  handleInputChange('birthDate', '');
+                }
+              }}
+              label="생년월일"
+              placeholder="YYYY-MM-DD"
+            />
 
             {/* Submit */}
             <Button

--- a/src/pages/auth/Signup.tsx
+++ b/src/pages/auth/Signup.tsx
@@ -180,18 +180,8 @@ const Signup: React.FC = () => {
 
             {/* Birth Date */}
             <Calendar28
-              value={formData.birthDate ? new Date(formData.birthDate) : null}
-              onChange={(date) => {
-                if (date) {
-                  const timezoneOffset = date.getTimezoneOffset() * 60000;
-                  const localDate = new Date(date.getTime() - timezoneOffset)
-                    .toISOString()
-                    .substring(0, 10); // YYYY-MM-DD 형식
-                  handleInputChange('birthDate', localDate);
-                } else {
-                  handleInputChange('birthDate', '');
-                }
-              }}
+              value={formData.birthDate}
+              onChange={(val) => handleInputChange('birthDate', val)}
               label="생년월일"
               placeholder="YYYY-MM-DD"
             />


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #153 

### 🔎 작업 내용

- [x] 타임존 보정 로직 추가
toISOString()의 UTC 기준 반환값을 보정하여 날짜 -1 현상 해결
Calendar28 내부에서 getTimezoneOffset()을 활용해 자동 보정 처리

- [x] Calendar28 컴포넌트 개선
value와 onChange의 타입을 Date → string (YYYY-MM-DD)으로 변경
내부에서 문자열-날짜 변환 및 timezone 보정 로직을 모두 처리하여 외부에서 중복 처리하지 않도록 개선
Popover, Input, Calendar 컴포넌트 간 상태 연동을 유지하면서 UX 유지

- [x] Signup.tsx 리팩토링
Calendar28 컴포넌트 사용을 간결하게 변경
handleInputChange('birthDate', value)로만 처리되도록 단순화

### 📸 스크린샷
>회원가입 생년월일 오류 수정
- 날짜 선택 시 입력값이 YYYY-MM-DD 형식으로 정확히 들어오는지 확인
- 생년월일 input을 수동 입력해도 날짜 보정 및 유효성 검증이 정상 작동하는지 테스트 완료

<img src="https://github.com/user-attachments/assets/4f386c25-f3b3-45e8-8dc2-304ed54abfe3" width="200" height="350"/>

- 추가한 라이브러리나 특이 사항
https://velog.io/@diso592/Date-라이브러리-dafe-fns-2.-timezone

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
