### PR TITLE
Feat: [EVER-242] 채팅 화면에서 Back to Top 버튼 구현 및 스크롤 훅 추가 

### DIFF
--- a/src/components/common/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/src/components/common/ScrollToTopButton/ScrollToTopButton.tsx
@@ -1,0 +1,26 @@
+import { ArrowUp } from 'lucide-react';
+import { Button } from '@/components/Button';
+import { useScrollToTop } from '@/hooks/useScrollToTop';
+
+interface ScrollToTopButtonProps {
+  scrollRef: React.RefObject<HTMLElement | null>;
+}
+
+export const ScrollToTopButton: React.FC<ScrollToTopButtonProps> = ({ scrollRef }) => {
+  const { show, scrollToTop } = useScrollToTop(scrollRef);
+
+  if (!show) return null;
+
+  return (
+    <div className="fixed bottom-[200px] right-8 z-50">
+      <Button
+        variant="login"
+        size="icon"
+        className="rounded-full shadow-lg cursor-pointer"
+        onClick={scrollToTop}
+      >
+        <ArrowUp className="w-5 h-5" />
+      </Button>
+    </div>
+  );
+};

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,0 +1,16 @@
+import { useScrollStore } from '@/stores/useScrollStore';
+
+export const useScrollToTop = (ref: React.RefObject<HTMLElement | null>) => {
+  const y = useScrollStore((s) => s.y);
+
+  const show = y > 200;
+
+  const scrollToTop = () => {
+    const el = ref?.current;
+    if (el) {
+      el.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
+
+  return { show, scrollToTop };
+};

--- a/src/hooks/useScrollTracker.ts
+++ b/src/hooks/useScrollTracker.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useScrollStore } from '@/stores/useScrollStore';
+
+export const useScrollTracker = (ref: React.RefObject<HTMLElement | null>) => {
+  const setY = useScrollStore((s) => s.setY);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      setY(el.scrollTop);
+    };
+
+    el.addEventListener('scroll', handleScroll);
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [ref, setY]);
+};

--- a/src/pages/chatbot/ChatContainer/ChatContainer.tsx
+++ b/src/pages/chatbot/ChatContainer/ChatContainer.tsx
@@ -15,8 +15,14 @@ import { ChatInputArea } from '../ChatInputArea/ChatInputArea';
 import { LoadingOverlay } from '../../ubti/LoadingOverlay';
 import { SubscriptionRecommendationsData } from '@/types/streaming';
 import { fetchUBTIResult } from '@/apis/ubti/ubti';
+import { useScrollTracker } from '@/hooks/useScrollTracker';
+import { ScrollToTopButton } from '@/components/common/ScrollToTopButton/ScrollToTopButton';
 
 export const ChatContainer: React.FC = () => {
+  // 스크롤 이벤트 감지용
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useScrollTracker(scrollRef);
+
   const [isMunerTone, setIsMunerTone] = useState(false);
   const [isLoadingResult, setIsLoadingResult] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -321,6 +327,7 @@ export const ChatContainer: React.FC = () => {
           currentSubscriptionRecommendations as SubscriptionRecommendationsData
         }
         messagesEndRef={messagesEndRef}
+        scrollRef={scrollRef}
       />
 
       {/* 입력 영역 */}
@@ -336,6 +343,8 @@ export const ChatContainer: React.FC = () => {
         onUsageRecommendation={handleUsageRecommendation}
         onResetChat={resetChat}
       />
+
+      <ScrollToTopButton scrollRef={scrollRef} />
     </div>
   );
 };

--- a/src/pages/chatbot/ChatMessages.tsx
+++ b/src/pages/chatbot/ChatMessages.tsx
@@ -13,45 +13,36 @@ interface ChatMessagesProps {
   currentPlanRecommendations: PlanRecommendation[];
   currentSubscriptionRecommendations: SubscriptionRecommendationsData | null;
   messagesEndRef: React.RefObject<HTMLDivElement> | React.MutableRefObject<HTMLDivElement | null>;
+  scrollRef: React.RefObject<HTMLDivElement | null>;
 }
 
 export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(
-  ({ messages, isStreaming, streamingState, messagesEndRef }) => {
-    // 최신 봇 메시지 ID 계산
+  ({ scrollRef, messages, isStreaming, streamingState, messagesEndRef }) => {
     const latestBotMessageId = React.useMemo(() => {
       const botMessages = messages.filter((msg) => msg.type === 'bot');
       return botMessages.length > 0 ? botMessages[botMessages.length - 1].id : null;
     }, [messages]);
 
-    // 스트리밍 상태에 따른 로딩 컴포넌트 렌더링
     const renderLoadingState = React.useCallback(() => {
       switch (streamingState) {
         case 'waiting':
           return <TypingIndicator />;
-
         case 'receiving_cards':
-          // 카드 대기 중
           return <CardLoadingIndicator />;
-
         case 'receiving_text':
-          // 텍스트 수신 중에는 기존 ChatBubble을 사용하되 스트리밍 효과만 추가
           return null;
-
         default:
           return null;
       }
     }, [streamingState]);
 
     return (
-      <div className="flex-1 overflow-y-auto pb-4">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto pb-4">
         <div className="flex flex-col space-y-2">
-          {/* 기존 메시지들 */}
           {messages.map((message: Message, index: number) => {
             const isLastMessage = index === messages.length - 1;
             const isLastBotMessage = isLastMessage && message.type === 'bot';
             const isStreamingNow = isStreaming && isLastBotMessage;
-
-            // 최신 봇 메시지인지 확인
             const isLatestBotMessage = message.type === 'bot' && message.id === latestBotMessageId;
 
             return (
@@ -59,14 +50,12 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(
                 key={message.id || `msg-${index}`}
                 message={message}
                 isStreaming={isStreamingNow}
-                isLatestBotMessage={isLatestBotMessage} // 새로운 prop 전달
+                isLatestBotMessage={isLatestBotMessage}
               />
             );
           })}
 
-          {/* 스트리밍 상태에 따른 로딩 표시 */}
           {isStreaming && renderLoadingState()}
-
           <div ref={messagesEndRef} />
         </div>
       </div>

--- a/src/stores/useScrollStore.ts
+++ b/src/stores/useScrollStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ScrollState {
+  y: number;
+  setY: (y: number) => void;
+}
+
+export const useScrollStore = create<ScrollState>((set) => ({
+  y: 0,
+  setY: (y) => set({ y }),
+}));


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #167 

### 🔎 작업 내용
- [x] 채팅창 스크롤 위치를 전역 상태(Zustand)로 관리해 어느 컴포넌트에서도 참조 가능하게 했습니다.
- [x] 채팅창 스크롤이 일정 이상(`y=200px`) 내려가면 상단 이동 버튼이 나타납니다.
   버튼 클릭 시 부드럽게 최상단으로 스크롤됩니다ㅎㅎ
- [x] 내부 스크롤을 추적하기 위해 useScrollTracker 훅과 scrollRef를 사용해 안정적으로 위치를 측정합니다.


### 📸 스크린샷
![ezgif-5482aaad5c60c8](https://github.com/user-attachments/assets/6fa88738-65ad-43fc-813d-dcea6b5c0789)

### :loudspeaker: 전달사항
> useScrollTracker는 스크롤 위치를 추적해서 전역 상태로 저장해주는 훅입니다~
  제 생각에 채팅 페이지 빼고 이 버튼을 사용할 일은 없을 것 같은데 필요하시면 해당 PR의 로직 참고해서 추가해주세요! 
- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
