### PR TITLE
feat: [EVER-248] like -> likecoupon change complete

### DIFF
--- a/src/apis/coupon/changeCouponlike.ts
+++ b/src/apis/coupon/changeCouponlike.ts
@@ -1,0 +1,4 @@
+import { apiWithToken } from '@/lib/api/apiconfig';
+
+export const changeCouponLike = (couponId: number) =>
+  apiWithToken.post(`/coupons/${couponId}/like`);

--- a/src/pages/hotplace/StoreMap/StoreMap.tsx
+++ b/src/pages/hotplace/StoreMap/StoreMap.tsx
@@ -14,6 +14,7 @@ interface StoreMapProps {
   allBrandIds: number[];
   selectedIds: number[];
   onLoadingChange?: (loading: boolean) => void;
+  onChangeSelectedIds?: (ids: number[]) => void;
 }
 
 interface StoreData {
@@ -30,9 +31,8 @@ export default function StoreMap({
   selectedIds,
   allBrandIds,
   onLoadingChange,
+  onChangeSelectedIds,
 }: StoreMapProps) {
-  const [selectedBrandIds, setSelectedBrandIds] = useState<number[]>([]);
-
   const [nearbyStores, setNearbyStores] = useState<StoreData[]>([]);
   const [currentLocation, setCurrentLocation] = useState<{ lat: number; lng: number }>({
     lat: 37.503325874722,
@@ -55,11 +55,6 @@ export default function StoreMap({
   const currentLocationMarkerRef = useRef<naver.maps.Marker | null>(null);
   const mapEventListenersRef = useRef<naver.maps.MapEventListener[]>([]);
   const markersInitializedRef = useRef(false);
-
-  // selectedIds prop이 바뀌면 내부 상태 동기화
-  useEffect(() => {
-    setSelectedBrandIds(selectedIds);
-  }, [selectedIds]);
 
   const openPopover = useCallback((store: StoreData) => {
     setSelectedStore(store);
@@ -84,7 +79,7 @@ export default function StoreMap({
           return;
         }
 
-        if (selectedBrandIds.length === 0) {
+        if (selectedIds.length === 0) {
           setNearbyStores([]);
           setLoading(false);
           return;
@@ -93,7 +88,7 @@ export default function StoreMap({
         const response = await getNearbyCoupons(
           currentLocation.lat,
           currentLocation.lng,
-          selectedBrandIds,
+          selectedIds,
         );
 
         if (Array.isArray(response)) {
@@ -117,9 +112,8 @@ export default function StoreMap({
     };
 
     fetchStores();
-  }, [currentLocation, selectedBrandIds]);
+  }, [currentLocation, selectedIds]);
 
-  // 현재 위치 가져오기
   const getCurrentLocation = useCallback(() => {
     if (!navigator.geolocation) {
       alert('이 브라우저는 위치 서비스를 지원하지 않습니다.');
@@ -365,8 +359,8 @@ export default function StoreMap({
         loadingLocation={loadingLocation}
         onGetCurrentLocation={getCurrentLocation}
         brandIds={allBrandIds}
-        selectedIds={selectedBrandIds}
-        onChangeSelectedIds={setSelectedBrandIds}
+        selectedIds={selectedIds}
+        onChangeSelectedIds={onChangeSelectedIds ?? (() => {})}
       />
 
       <MapLegend popupCount={nearbyStores.length} hasCurrentLocation={!!currentLocation} />


### PR DESCRIPTION
### #️⃣연관된 이슈

> close: #179 

### 🔎 작업 내용

- [x] 좋아요한 브랜드 react-query 기반 상태 좋아요 버튼에 따라 바뀌게 변경
- [x] 지도 무한 로딩 현상 수정
- [x] 좋아요한 브랜드를 브랜드 선택에서 기본값으로 사용하도록 변경  

### 📸 스크린샷

https://github.com/user-attachments/assets/972893c2-3dc7-45f6-a7f6-26adb3c19e67

### :loudspeaker: 전달사항

- 지도 무한 로딩은 StoreMap에서 외부 props를 내부 state로 받아 쓰는 바람에, props 변경 -> setState로 내부 state 변경 -> useEffect 때문에 API 다시 실행 -> props값 또 변경의 무한 루프 떄문에 발생했습니다 <- 내부 state없애버려서 해결 완료
- 좋아요한 브랜드 query가 반영되긴하는데, 좋아요한 쿠폰 페이지에서 살짝 딜레이가 있는 거로 확인되어, 리팩토링 한다면 타임아웃 넣어서 좀 기다리게 하는게 ux적으로는 좋아보입니다

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
