### PR TITLE
Refactor: [EVER-259] 유저 베타테스트 QA 피드백 반영 - 0603

### DIFF
--- a/src/apis/coupon/changeCouponlike.ts
+++ b/src/apis/coupon/changeCouponlike.ts
@@ -1,4 +1,14 @@
 import { apiWithToken } from '@/lib/api/apiconfig';
 
-export const changeCouponLike = (couponId: number) =>
+// TODO: 인터페이스 타입으로 분리 필요
+interface CouponLikeResponse {
+  status: number;
+  message: string;
+  data: {
+    liked: boolean;
+    coupon_id: number;
+  };
+}
+
+export const changeCouponLike = (couponId: number): Promise<{ data: CouponLikeResponse }> =>
   apiWithToken.post(`/coupons/${couponId}/like`);

--- a/src/apis/plan/postPlan.ts
+++ b/src/apis/plan/postPlan.ts
@@ -6,5 +6,5 @@ import { apiWithToken } from '@/lib/api/apiconfig';
  */
 export const changePlan = async (planId: number) => {
   const res = await apiWithToken.post('/user/plans', { plan_id: planId });
-  return res?.data?.data;
+  return res?.data;
 };

--- a/src/components/SubscriptionCard/SubscriptionCard.tsx
+++ b/src/components/SubscriptionCard/SubscriptionCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/Button';
-import { Heart, Plus, Play, Coffee, Bookmark } from 'lucide-react';
+import { Plus, Play, Coffee, Heart } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { MainSubscription, LifeBrand, SubscriptionRecommendationsData } from '@/types/streaming';
 
@@ -40,11 +40,8 @@ export const SubscriptionCard: React.FC<SubscriptionCardProps> = React.memo(
       >
         {/* 헤더 */}
         <div className="px-3 pt-3 pb-2">
-          <div className="flex items-center gap-2">
-            <Heart className="w-4 h-4 text-pink-500 flex-shrink-0" />
-            <span className="text-sm font-bold text-purple-800 truncate">무너의 추천 조합</span>
-            <span className="text-base">🐙</span>
-          </div>
+          <span className="text-sm font-bold text-purple-800 truncate pl-1">무너의 추천 조합</span>
+          <span className="text-base">🐙</span>
         </div>
 
         <CardContent className="px-3 pb-3 space-y-3">
@@ -159,8 +156,8 @@ export const SubscriptionCard: React.FC<SubscriptionCardProps> = React.memo(
                   onClick={handleBrandClick}
                   className="border-green-600 text-green-600 hover:bg-green-50 text-xs py-1.5 h-auto"
                 >
-                  <Bookmark className="w-3 h-3 mr-1" />
-                  쿠폰 찜하기
+                  <Heart className="w-3 h-3 mr-1" />
+                  쿠폰 좋아요
                 </Button>
               </div>
             )}
@@ -171,11 +168,12 @@ export const SubscriptionCard: React.FC<SubscriptionCardProps> = React.memo(
               onSubscribe && (
                 <Button
                   size="default"
-                  onClick={handleSubscribeClick}
-                  className="w-full bg-blue-600 hover:bg-blue-700 text-white py-1.5 h-auto"
+                  variant="outline"
+                  onClick={handleBrandClick}
+                  className="border-red-400 text-red-500 hover:bg-red-50 text-xs py-1.5 h-auto"
                 >
-                  <Play className="w-3 h-3 mr-1" />
-                  구독하러 가기
+                  <Heart className="w-3 h-3 mr-1 text-red-500" />
+                  좋아요
                 </Button>
               )}
 
@@ -188,10 +186,10 @@ export const SubscriptionCard: React.FC<SubscriptionCardProps> = React.memo(
                   size="default"
                   variant="outline"
                   onClick={handleBrandClick}
-                  className="w-full border-green-600 text-green-600 hover:bg-green-50 py-1.5 h-auto"
+                  className="border-red-400 text-red-500 hover:bg-red-50 text-xs py-1.5 h-auto"
                 >
-                  <Bookmark className="w-3 h-3 mr-1" />
-                  쿠폰 찜하기
+                  <Heart className="w-3 h-3 mr-1 text-red-500" />
+                  좋아요
                 </Button>
               )}
           </div>

--- a/src/pages/chatbot/ChatBubble.tsx
+++ b/src/pages/chatbot/ChatBubble.tsx
@@ -11,6 +11,8 @@ import { cn } from '@/lib/utils';
 import { IMAGES } from '@/constant/imagePath';
 import { useNavigate } from 'react-router-dom';
 import { PlanSwiper } from '@/components/PlanCard/PlanSwiper';
+import { toast } from 'sonner';
+import { changeCouponLike } from '@/apis/coupon/changeCouponlike';
 
 interface ChatBubbleProps {
   message: Message;
@@ -211,20 +213,43 @@ const ChatBubble: React.FC<ChatBubbleProps> = React.memo(
       navigate(`/plans/${plan.id}`);
     }, []);
 
-    const handleSubscriptionSelect = React.useCallback(
-      (
-        subscription: NonNullable<typeof message.subscriptionRecommendations>['main_subscription'],
-      ) => {
-        console.log('[DEBUG] Subscription selected:', subscription);
-        navigate('/');
-      },
-      [navigate],
-    );
+    const handleSubscriptionSelect = React.useCallback(() => {
+      navigate('/home#subscription');
+    }, [navigate]);
 
     const handleBrandSelect = React.useCallback(
-      (brand: NonNullable<typeof message.subscriptionRecommendations>['life_brand']) => {
-        console.log('[DEBUG] Brand selected:', brand);
-        navigate('/hotplace');
+      (
+        brand:
+          | NonNullable<typeof message.subscriptionRecommendations>['life_brand']
+          | null
+          | undefined,
+      ) => {
+        if (!brand) {
+          toast.error('브랜드 정보가 없습니다.', {
+            description: '잠시 후 다시 시도해주세요',
+          });
+          return;
+        }
+        changeCouponLike(brand.id)
+          .then((response) => {
+            const isLiked = response.data.data.liked;
+
+            if (isLiked) {
+              toast.success('쿠폰을 찜했어요! 💜', {
+                description: '좋아요한 쿠폰함에서 확인할 수 있어요',
+              });
+            } else {
+              toast.success('쿠폰 찜을 해제했어요', {
+                description: '언제든 다시 찜할 수 있어요',
+              });
+            }
+          })
+          .catch((error) => {
+            console.error('쿠폰 좋아요 토글 실패:', error);
+            toast.error('쿠폰 찜하기에 실패했어요', {
+              description: '잠시 후 다시 시도해주세요',
+            });
+          });
       },
       [navigate],
     );

--- a/src/pages/chatbot/ChatInputArea/ChatInputArea.tsx
+++ b/src/pages/chatbot/ChatInputArea/ChatInputArea.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { ChatInput } from './ChatInput';
 import { ServiceCard } from './ServiceCard';
 import { Button } from '@/components/Button';
@@ -36,6 +37,7 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
   const [showServiceDrawer, setShowServiceDrawer] = React.useState(false);
   const [showTooltip, setShowTooltip] = React.useState(false);
   const { isLoggedIn } = useAuthStore();
+  const navigate = useNavigate();
 
   // Alert 상태
   const [alert, setAlert] = React.useState<AlertState | null>(null);
@@ -194,7 +196,6 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                   </div>
                 </div>
               )}
-
               {/* Services Grid - 2x2 그리드 */}
               <div className="grid grid-cols-2 gap-4 max-w-sm mx-auto">
                 {services.map((service) => (
@@ -208,11 +209,14 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
               </div>
 
               <div className="text-center mt-6">
-                <p className="text-xs text-gray-500">
+                <p className="text-caption-1 text-gray-500 pb-3">
                   {isLoggedIn
                     ? '원하는 서비스를 선택해보세요 ✨'
-                    : '지금 로그인하고 모든 기능을 이용해보세요! 🔐'}
+                    : '지금 바로 로그인하러 가볼까요? 🔐'}
                 </p>
+                <Button size="lg" variant="login" onClick={() => navigate('/login')}>
+                  로그인하기
+                </Button>
               </div>
             </motion.div>
           </>

--- a/src/pages/chatbot/ChatInputArea/ChatInputArea.tsx
+++ b/src/pages/chatbot/ChatInputArea/ChatInputArea.tsx
@@ -214,9 +214,11 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                     ? '원하는 서비스를 선택해보세요 ✨'
                     : '지금 바로 로그인하러 가볼까요? 🔐'}
                 </p>
-                <Button size="lg" variant="login" onClick={() => navigate('/login')}>
-                  로그인하기
-                </Button>
+                {!isLoggedIn && (
+                  <Button size="lg" variant="login" onClick={() => navigate('/login')}>
+                    로그인하기
+                  </Button>
+                )}
               </div>
             </motion.div>
           </>

--- a/src/pages/chatbot/ChatbotIntroTutorial.tsx
+++ b/src/pages/chatbot/ChatbotIntroTutorial.tsx
@@ -1,0 +1,241 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, ArrowRight, MessageCircle, Plus, ToggleLeft, Sparkles } from 'lucide-react';
+import { Button } from '@/components/Button';
+import { IMAGES } from '@/constant/imagePath';
+
+interface ChatbotIntroTutorialProps {
+  isVisible: boolean;
+  onClose: () => void;
+}
+
+interface TutorialStep {
+  id: number;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  highlight?: string;
+  position?: {
+    top?: string;
+    bottom?: string;
+    left?: string;
+    right?: string;
+  };
+}
+
+const tutorialSteps: TutorialStep[] = [
+  {
+    id: 1,
+    title: '무너와 대화하기',
+    description:
+      '무너는 LG유플러스의 AI 어시스턴트예요!\n요금제, 구독 서비스 등 뭐든지 물어보세요.',
+    icon: <MessageCircle className="w-8 h-8 text-blue-500" />,
+  },
+  {
+    id: 2,
+    title: '플러스(+) 버튼의 비밀',
+    description: '채팅창 왼쪽의 + 버튼을 누르면\n특별한 서비스 메뉴가 나타나요!',
+    icon: <Plus className="w-8 h-8 text-green-500" />,
+    highlight: 'plus-button',
+    position: { bottom: '100px', left: '20px' },
+  },
+  {
+    id: 3,
+    title: '타코시그널 검사',
+    description: '나만의 통신 유형을 알아보는\n재미있는 성격 검사예요! 🐙',
+    icon: <Sparkles className="w-8 h-8 text-purple-500" />,
+  },
+  {
+    id: 4,
+    title: '톤 스위치 기능',
+    description: '무너를 정중한 모드 ↔ MZ 모드로\n바꿀 수 있어요! (로그인 필요)',
+    icon: <ToggleLeft className="w-8 h-8 text-orange-500" />,
+    highlight: 'tone-switch',
+    position: { top: '20px', right: '20px' },
+  },
+];
+
+export const ChatbotIntroTutorial: React.FC<ChatbotIntroTutorialProps> = ({
+  isVisible,
+  onClose,
+}) => {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [isClosing, setIsClosing] = useState(false);
+
+  const handleNext = () => {
+    if (currentStep < tutorialSteps.length - 1) {
+      setCurrentStep(currentStep + 1);
+    } else {
+      handleClose();
+    }
+  };
+
+  const handleClose = () => {
+    setIsClosing(true);
+    localStorage.setItem('hasSeenChatbotTutorial', 'true');
+    setTimeout(() => {
+      onClose();
+      setIsClosing(false);
+    }, 300);
+  };
+
+  const handleSkip = () => {
+    handleClose();
+  };
+
+  if (!isVisible) return null;
+
+  const step = tutorialSteps[currentStep];
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <>
+          {/* 배경 오버레이 */}
+          <motion.div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[9999]"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: isClosing ? 0 : 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+          />
+
+          {/* 하이라이트 영역  */}
+          {step.highlight && step.position && (
+            <motion.div
+              className="fixed z-[10000] pointer-events-none"
+              style={step.position}
+              initial={{ scale: 0, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ delay: 0.2, type: 'spring' }}
+            >
+              <div className="w-12 h-12 rounded-full border-4 border-yellow-400 animate-pulse" />
+              <div className="absolute inset-0 w-12 h-12 rounded-full bg-yellow-400/20 animate-ping" />
+            </motion.div>
+          )}
+
+          {/* 메인 튜토리얼 카드 */}
+          <motion.div
+            className="fixed inset-0 z-[10001] flex items-center justify-center p-4"
+            initial={{ opacity: 0, y: 100, scale: 0.8 }}
+            animate={{
+              opacity: isClosing ? 0 : 1,
+              y: isClosing ? 100 : 0,
+              scale: isClosing ? 0.8 : 1,
+            }}
+            transition={{ type: 'spring', damping: 20 }}
+          >
+            <div className="bg-white rounded-3xl shadow-2xl border-4 border-yellow-300 p-6 w-full max-w-md relative overflow-hidden">
+              {/* 배경 데코레이션 */}
+              <div className="absolute top-0 right-0 w-32 h-32 bg-gradient-to-br from-yellow-200/30 to-orange-200/30 rounded-full -translate-y-16 translate-x-16" />
+              <div className="absolute bottom-0 left-0 w-24 h-24 bg-gradient-to-tr from-blue-200/30 to-purple-200/30 rounded-full translate-y-12 -translate-x-12" />
+
+              {/* 닫기 버튼 */}
+              <button
+                onClick={handleClose}
+                className="absolute top-4 right-4 p-2 rounded-full hover:bg-gray-100 transition-colors z-10"
+              >
+                <X className="w-5 h-5 text-gray-500" />
+              </button>
+
+              {/* 무너 캐릭터 */}
+              <div className="flex justify-center mb-6 relative z-10">
+                <motion.img
+                  src={IMAGES.MOONER['mooner-chat']}
+                  alt="무너"
+                  className="w-20 h-20 rounded-full shadow-lg"
+                  animate={{
+                    scale: [1, 1.1, 1],
+                    rotate: [0, 5, -5, 0],
+                  }}
+                  transition={{ duration: 2, repeat: Infinity }}
+                />
+              </div>
+
+              {/* 튜토리얼 내용 */}
+              <div className="text-center relative z-10">
+                {/* 아이콘 */}
+                <motion.div
+                  className="flex justify-center mb-4"
+                  key={step.id}
+                  initial={{ scale: 0, rotate: 180 }}
+                  animate={{ scale: 1, rotate: 0 }}
+                  transition={{ type: 'spring', damping: 15 }}
+                >
+                  {step.icon}
+                </motion.div>
+
+                {/* 제목 */}
+                <motion.h2
+                  className="text-xl font-bold text-gray-800 mb-3"
+                  key={`title-${step.id}`}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.1 }}
+                >
+                  {step.title}
+                </motion.h2>
+
+                {/* 설명 */}
+                <motion.p
+                  className="text-gray-600 text-sm leading-relaxed mb-6 whitespace-pre-line px-2"
+                  key={`desc-${step.id}`}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.2 }}
+                >
+                  {step.description}
+                </motion.p>
+
+                {/* 진행 표시 */}
+                <div className="flex justify-center space-x-2 mb-6">
+                  {tutorialSteps.map((_, index) => (
+                    <motion.div
+                      key={index}
+                      className={`w-2 h-2 rounded-full transition-all duration-300 ${
+                        index === currentStep ? 'bg-yellow-400 w-6' : 'bg-gray-300'
+                      }`}
+                      animate={index === currentStep ? { scale: [1, 1.2, 1] } : {}}
+                      transition={{ duration: 1, repeat: Infinity }}
+                    />
+                  ))}
+                </div>
+
+                {/* 버튼들 */}
+                <div className="flex gap-3 justify-center">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSkip}
+                    className="flex-1 max-w-[120px]" // 최대 너비 제한
+                  >
+                    건너뛰기
+                  </Button>
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={handleNext}
+                    className="flex-1 max-w-[120px] bg-yellow-400 hover:bg-yellow-500 text-gray-800" // 최대 너비 제한
+                  >
+                    {currentStep === tutorialSteps.length - 1 ? (
+                      '시작하기'
+                    ) : (
+                      <>
+                        다음 <ArrowRight className="w-4 h-4 ml-1" />
+                      </>
+                    )}
+                  </Button>
+                </div>
+
+                {/* 단계 표시 */}
+                <p className="text-xs text-gray-500 mt-3">
+                  {currentStep + 1} / {tutorialSteps.length}
+                </p>
+              </div>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/pages/home/Subscription.tsx
+++ b/src/pages/home/Subscription.tsx
@@ -1,10 +1,25 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { SubscriptionSteps } from './SubscriptionSteps/SubscriptionSteps';
 import { Card, CardContent } from '@/components/Card';
 
 const Subscription: React.FC = () => {
+  const subscriptionRef = useRef<HTMLDivElement>(null);
+
+  // 해시 감지
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (hash === '#subscription' && subscriptionRef.current) {
+      subscriptionRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+      // 해시 제거
+      window.history.replaceState({}, '', window.location.pathname);
+    }
+  }, []);
+
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" ref={subscriptionRef}>
       <div>
         <h1 className="text-xl font-bold text-brand-darkblue mb-4">유독Pick</h1>
         <Card>

--- a/src/pages/plan/Plan.tsx
+++ b/src/pages/plan/Plan.tsx
@@ -111,9 +111,37 @@ const PlanPage: React.FC = () => {
 
   // 요금제 상세 페이지 이동
   if (id) {
+    if (detailLoading) {
+      return (
+        <div className="flex items-center justify-center h-full">
+          <div className="flex flex-col items-center space-y-4">
+            <div className="animate-spin w-8 h-8 border-4 border-brand-yellow border-t-transparent rounded-full" />
+            <p className="text-gray-600 text-sm">요금제 상세 정보를 불러오는 중...</p>
+          </div>
+        </div>
+      );
+    }
+
+    if (detailError || !planDetail) {
+      return (
+        <div className="flex items-center justify-center h-full">
+          <div className="text-center">
+            <div className="text-red-500 text-lg font-medium mb-2">요금제를 찾을 수 없습니다</div>
+            <p className="text-gray-600 mb-4">요청하신 요금제가 존재하지 않습니다.</p>
+            <button
+              onClick={() => navigate('/plans')}
+              className="px-4 py-2 bg-brand-yellow text-white rounded-lg hover:bg-brand-yellow-hover"
+            >
+              목록으로 돌아가기
+            </button>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="h-full">
-        <PlanCard plan={normalizePlan(planDetail!)} />
+        <PlanCard plan={normalizePlan(planDetail)} />
       </div>
     );
   }

--- a/src/pages/plan/PlanDetail.tsx
+++ b/src/pages/plan/PlanDetail.tsx
@@ -39,7 +39,7 @@ const PlanDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { openModal } = useModalStore();
   const navigate = useNavigate();
-  const { data: plan, error } = usePlanDetail(id ?? '');
+  const { data: plan, error, isLoading } = usePlanDetail(id ?? '');
   const { data: userProfile } = useUserProfile(); // 🔧 사용자 정보 가져오기
   const [isChanging, setIsChanging] = useState(false);
   const { isLoggedIn } = useAuthStore();
@@ -150,6 +150,17 @@ const PlanDetail: React.FC = () => {
       setIsChanging(false);
     }
   };
+
+  if (isLoading) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="flex flex-col items-center space-y-4">
+          <div className="animate-spin w-8 h-8 border-4 border-brand-yellow border-t-transparent rounded-full" />
+          <p className="text-gray-600 text-sm">요금제 정보를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
 
   if (error || !plan) {
     return (

--- a/src/pages/ubti/MatchingTypeCard.tsx
+++ b/src/pages/ubti/MatchingTypeCard.tsx
@@ -57,7 +57,7 @@ export const MatchingTypeCard: React.FC<MatchingTypeCardProps> = ({ matchingType
           💕 나와 찰떡궁합인 타입
         </motion.h2>
 
-        {/* API에서 받은 이미지가 있으면 이미지 사용, 없으면 이모지 사용 */}
+        {/* image_url이 있으면 이미지, 없으면 이모지 */}
         {matchingType.image_url ? (
           <motion.div
             className="mb-6 flex justify-center relative"
@@ -69,28 +69,12 @@ export const MatchingTypeCard: React.FC<MatchingTypeCardProps> = ({ matchingType
             <img
               src={matchingType.image_url}
               alt={matchingType.name}
-              className="w-24 h-24 object-contain rounded-2xl shadow-lg"
-              onError={(e) => {
-                // 이미지 로드 실패 시 이모지로 대체
-                e.currentTarget.style.display = 'none';
-                const emojiElement = e.currentTarget.nextElementSibling as HTMLElement;
-                if (emojiElement) {
-                  emojiElement.style.display = 'block';
-                }
-              }}
+              className="w-24 h-24 object-contain rounded-2xl shadow-lg relative z-10"
             />
-            <motion.div
-              className="text-6xl hidden absolute inset-0 flex items-center justify-center" // 기본적으로 숨김
-              animate={{
-                scale: [1, 1.1, 1],
-              }}
-              transition={{ duration: 3, repeat: Infinity }}
-            >
-              {matchingType.emoji}
-            </motion.div>
 
+            {/* 반짝이 효과 */}
             <motion.div
-              className="absolute -top-2 -right-2 text-yellow-400 text-xl"
+              className="absolute -top-2 -right-2 text-yellow-400 text-xl z-20"
               animate={{
                 scale: [0, 1.2, 0],
                 opacity: [0, 1, 0],

--- a/src/pages/ubti/TacoCookingAnimation.tsx
+++ b/src/pages/ubti/TacoCookingAnimation.tsx
@@ -23,7 +23,6 @@ export const TacoCookingAnimation: React.FC<TacoCookingAnimationProps> = ({
   isBaked,
   isRevealed,
   ubtiType,
-  stepMessages,
 }) => {
   return (
     <div className="relative min-h-full flex flex-col py-2 items-center justify-centers">
@@ -59,9 +58,7 @@ export const TacoCookingAnimation: React.FC<TacoCookingAnimationProps> = ({
           transition={{ type: 'spring', damping: 15 }}
         >
           <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 w-4 h-4 bg-white border-l-3 border-t-3 border-pink-300 rotate-45" />
-          <span className="text-medium font-semibold text-gray-700 block text-center">
-            {stepMessages[currentStep]?.[messageIndex] || stepMessages[0][0]}
-          </span>
+          <span className="text-medium font-semibold text-gray-700 block text-center"></span>
         </motion.div>
       </AnimatePresence>
 
@@ -87,7 +84,7 @@ export const TacoCookingAnimation: React.FC<TacoCookingAnimationProps> = ({
           }}
         />
 
-        {/* 요리 효과 */}
+        {/* 요리 효과들 - 기존과 동일 */}
         {currentStep >= 1 && (
           <>
             {/* 증기 효과 */}
@@ -194,22 +191,42 @@ export const TacoCookingAnimation: React.FC<TacoCookingAnimationProps> = ({
           </>
         )}
 
-        {/* 타코야끼 그리드 */}
+        {/* 🔧 타코야끼 그리드 - 동적 이미지 로직 개선 */}
         <div className="absolute top-[14%] left-[16%] w-[68%] h-[68%] grid grid-cols-3 grid-rows-3 place-items-center z-10">
           {[...Array(9)].map((_, i) => {
             const isCenter = i === 4;
 
-            const frontImage = isRevealed
-              ? isCenter
-                ? ubtiType?.front_image || IMAGES.TACO['taco-wasab-front']
-                : IMAGES.TACO['taco-sub-front']
-              : IMAGES.TACO['taco-main-front'];
+            // 동적 이미지 선택 로직 개선
+            const frontImage = (() => {
+              if (isRevealed) {
+                if (isCenter && ubtiType?.front_image) {
+                  // 중앙에 실제 UBTI 타입 이미지 사용
+                  return ubtiType.front_image;
+                } else {
+                  // 주변에는 기본 이미지
+                  return IMAGES.TACO['taco-sub-front'];
+                }
+              } else {
+                // 아직 공개되지 않음
+                return IMAGES.TACO['taco-main-front'];
+              }
+            })();
 
-            const backImage = isBaked
-              ? isCenter
-                ? ubtiType?.back_image || IMAGES.TACO['taco-wasab-back']
-                : IMAGES.TACO['taco-sub-back']
-              : IMAGES.TACO['taco-main-back'];
+            const backImage = (() => {
+              if (isBaked) {
+                if (isCenter && ubtiType?.back_image) {
+                  // 중앙에 실제 UBTI 타입 이미지 사용
+
+                  return ubtiType.back_image;
+                } else {
+                  // 주변에는 기본 이미지
+                  return IMAGES.TACO['taco-sub-back'];
+                }
+              } else {
+                // 아직 구워지지 않음
+                return IMAGES.TACO['taco-main-back'];
+              }
+            })();
 
             return (
               <motion.div
@@ -243,6 +260,10 @@ export const TacoCookingAnimation: React.FC<TacoCookingAnimationProps> = ({
                         : {}
                     }
                     transition={{ type: 'spring', damping: 10 }}
+                    // 이미지 로드 에러 시 기본 앞면
+                    onError={(e) => {
+                      e.currentTarget.src = IMAGES.TACO['taco-main-front'];
+                    }}
                   />
 
                   <motion.img
@@ -259,6 +280,10 @@ export const TacoCookingAnimation: React.FC<TacoCookingAnimationProps> = ({
                         : {}
                     }
                     transition={{ duration: 2, repeat: Infinity }}
+                    // 이미지 로드 에러 시 기본 뒷면
+                    onError={(e) => {
+                      e.currentTarget.src = IMAGES.TACO['taco-main-back'];
+                    }}
                   />
                 </ReactCardFlip>
               </motion.div>

--- a/src/pages/ubti/UBTI.tsx
+++ b/src/pages/ubti/UBTI.tsx
@@ -98,22 +98,37 @@ export const UBTI: React.FC = () => {
     }
   };
 
-  // 초기 데이터 로딩
   useEffect(() => {
     const state = location.state as UBTIResultResponse | undefined;
 
     if (state?.data) {
-      setShowResultLoading(true); // 결과 로딩 표시 시작
+      setShowResultLoading(true);
       setTimeout(() => {
         setResult(state.data);
+
+        // 동적 타코 이미지 설정 - ID별 매핑
+        const typeMapping: Record<number, { front: string; back: string }> = {
+          1: { front: 'taco-sub-front', back: 'taco-sub-back' }, // 말 많은 수다타코 (기본)
+          2: { front: 'taco-spicy-front', back: 'taco-spicy-back' }, // 열정 넘치는 매운타코
+          3: { front: 'taco-eggy-front', back: 'taco-eggy-back' }, // 집콕영상 마요타코
+          4: { front: 'taco-greeny-front', back: 'taco-greeny-back' }, // 감성뮤직 초록타코
+          5: { front: 'taco-milky-front', back: 'taco-milky-back' }, // 느긋한 라이트타코
+          6: { front: 'taco-berry-front', back: 'taco-berry-back' }, // 달콤상큼 베리타코
+          7: { front: 'taco-crunch-front', back: 'taco-crunch-back' }, // 달달꿀 허니타코
+          8: { front: 'taco-wasab-front', back: 'taco-wasab-back' }, // 시원한 민트타코
+        };
+
+        const tacoImages = typeMapping[state.data.ubti_type.id] || typeMapping[1]; // 기본값 설정
+
         setUbtiType({
-          front_image: IMAGES.TACO['taco-spicy-front'],
-          back_image: IMAGES.TACO['taco-spicy-back'],
+          front_image: IMAGES.TACO[tacoImages.front as keyof typeof IMAGES.TACO],
+          back_image: IMAGES.TACO[tacoImages.back as keyof typeof IMAGES.TACO],
         });
+
         setIsDataReady(true);
         setShowResultLoading(false);
         loadDetailedData(state.data);
-      }, 1500); // 결과 로딩 여부와 상관없이 지연 효과 추가
+      }, 1500);
     } else {
       console.log('데이터 로딩 실패');
       setShowResultLoading(false);

--- a/src/pages/ubti/UBTITypeCard.tsx
+++ b/src/pages/ubti/UBTITypeCard.tsx
@@ -22,6 +22,7 @@ export const UBTITypeCard: React.FC<UBTITypeCardProps> = ({ ubtiType }) => {
       <div className="absolute bottom-0 left-0 w-24 h-24 bg-orange-200/30 rounded-full translate-y-12 -translate-x-12" />
 
       <div className="text-center relative z-10">
+        {/* image_url이 있으면 이미지, 없으면 이모지 */}
         {ubtiType.image_url ? (
           <motion.div
             className="mb-6 flex justify-center"
@@ -35,25 +36,7 @@ export const UBTITypeCard: React.FC<UBTITypeCardProps> = ({ ubtiType }) => {
               src={ubtiType.image_url}
               alt={ubtiType.name}
               className="w-32 h-32 object-contain rounded-2xl shadow-lg"
-              onError={(e) => {
-                // 이미지 로드 실패 시 이모지로 대체
-                e.currentTarget.style.display = 'none';
-                const emojiElement = e.currentTarget.nextElementSibling as HTMLElement;
-                if (emojiElement) {
-                  emojiElement.style.display = 'block';
-                }
-              }}
             />
-            <motion.div
-              className="text-8xl hidden"
-              animate={{
-                rotate: [0, 5, -5, 0],
-                scale: [1, 1.1, 1],
-              }}
-              transition={{ duration: 3, repeat: Infinity }}
-            >
-              {ubtiType.emoji}
-            </motion.div>
           </motion.div>
         ) : (
           <motion.div


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #199 

### 🔎 작업 내용



- [x] 비로그인 상태에서 바텀 드로어 안내 문구 대신 로그인 버튼으로 교체
- [x] 매칭 타입 카드에서 이모지가 텍스트를 가리지 않도록 위치 및 크기 조정
- [x] 타코 이미지 동적 추가 : 총 3군데임 - 공유는 아직 추가 못함
- [x] 챗봇 플러스 버튼 기능 및 톤 스위치에 대한 툴팁 또는 안내 추가
- [x] 챗봇 시작 시 예시 질문 문구 추가
- [x] 요금제 변경 성공 후에도 표시되던 이상한 에러 sooner 고침
- [x] 무너의 추천조합 카드 맨 앞에 하트 이모지 삭제 (좋아요랑 헷갈린다고 함)
- [x] 구독하러 가기 / 쿠폰 찜하기 버튼에 실제 기능 연동 (링크 연결 또는 API 호출)


### 📸 스크린샷
> 이제 뒤집어질때 타코 잘나옴 ! (아마 DB에 s3 이미지링크로 넣어두면, 공유 페이지 빼곤 다 잘나올거에요 )
<img width="370" alt="스크린샷 2025-06-24 오전 1 10 36" src="https://github.com/user-attachments/assets/04369f1b-5743-4b1e-a64b-98b75684d5fe" />

> 챗봇 기능 설명하기 위해 처음 진입시 오버레이로 튜토리얼 추가
멘트는 추후 수정 ㄱ
![ezgif-33c9b7fa9b043b](https://github.com/user-attachments/assets/a0de8a33-e4bb-42c6-8d18-a1f13c0d4bbb)


### :loudspeaker: 전달사항
> 혜은언니 피드백 90퍼센트 반영함!! 아직 못한 건 디코에 적을게요~
- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
