### PR TITLE
Refactor: [EVER-258] 유저 베타테스트 QA 피드백 반영 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@tanstack/react-query": "^5.80.7",
         "@tanstack/react-query-devtools": "^5.81.0",
         "axios": "^1.9.0",
@@ -2909,6 +2910,15 @@
       },
       "peerDependencies": {
         "@svgr/core": "*"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -11340,7 +11350,6 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.10.tgz",
       "integrity": "sha512-P3nr6WkvKV/ONsTzj6Gb57sWPMX29EPNPopo7+FcpkQaNsrNpZ1pv8QmrYI2RqEKD7mlGqLnGovlcYnBK0IqUA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@tanstack/react-query": "^5.80.7",
     "@tanstack/react-query-devtools": "^5.81.0",
     "axios": "^1.9.0",

--- a/src/components/TopCouponCard/TopCouponCard.tsx
+++ b/src/components/TopCouponCard/TopCouponCard.tsx
@@ -73,10 +73,10 @@ const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
   const showSkeleton = isLoading || !deal;
 
   return (
-    <Card className="relative w-[176px] flex flex-col items-center px-3 py-3 gap-3 shadow-md rounded-xl">
+    <Card className="relative w-[160px] flex flex-col items-center px-3 py-3 gap-2 shadow-md rounded-xl">
       {/* 순위 뱃지 */}
       <div
-        className={`absolute -top-3 -left-3 w-8 h-8 rounded-full text-white text-xs flex items-center justify-center font-bold shadow-md ${
+        className={`absolute -top-3 -left-3 w-7 h-7 rounded-full text-white text-[10px] flex items-center justify-center font-bold shadow ${
           index === 0 ? 'bg-red-500' : index === 1 ? 'bg-yellow-500' : 'bg-gray-500'
         }`}
       >
@@ -107,8 +107,10 @@ const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
           </>
         ) : (
           <>
-            <CardTitle className="text-sm font-semibold">{deal.title}</CardTitle>
-            <CardDescription className="text-xs line-clamp-2">{deal.description}</CardDescription>
+            <CardTitle className="text-sm font-semibold leading-snug">{deal.title}</CardTitle>
+            <CardDescription className="text-xs leading-tight line-clamp-2">
+              {deal.description}
+            </CardDescription>
             <span className="text-red-500 text-xs font-bold">{getDiscountLabel(deal)}</span>
           </>
         )}
@@ -118,18 +120,3 @@ const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
 };
 
 export default TopCouponCard;
-
-// 내일 HotPlace.tsx 수정 – 카드 목록을 flex-row로
-{
-  /* <div className="flex flex-wrap gap-4 pt-4 justify-center">
-  {[0, 1, 2].map((index) => (
-    <TopCouponCard
-      key={index}
-      deal={bestDeals[index]}
-      index={index}
-      isLoading={isLoading}
-      getDiscountLabel={getDiscountLabel}
-    />
-  ))}
-</div> */
-}

--- a/src/components/TopCouponCard/TopCouponCard.tsx
+++ b/src/components/TopCouponCard/TopCouponCard.tsx
@@ -1,3 +1,64 @@
+// import { Card, CardContent, CardTitle, CardDescription } from '@/components/Card';
+// import { TopCoupon } from '@/apis/coupon/getTopCoupons';
+
+// interface Props {
+//   deal?: TopCoupon;
+//   index: number;
+//   isLoading: boolean;
+//   getDiscountLabel: (deal: TopCoupon) => string;
+// }
+
+// const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
+//   const showSkeleton = isLoading || !deal;
+
+//   return (
+//     <Card className="relative flex flex-row items-start px-4 py-3 gap-4 shadow-md rounded-xl">
+//       {/* 순위 뱃지 */}
+//       <div
+//         className={`absolute -top-3 -left-3 w-10 h-10 rounded-full text-white text-sm flex items-center justify-center font-bold shadow-md ${
+//           index === 0 ? 'bg-red-500' : index === 1 ? 'bg-yellow-500' : 'bg-gray-500'
+//         }`}
+//       >
+//         {index + 1}위
+//       </div>
+
+//       {/* 왼쪽: 브랜드명 + 이미지 */}
+//       <div className="flex flex-col items-center w-28 pt-4">
+//         {showSkeleton ? (
+//           <div className="w-20 h-4 bg-gray-200 mb-2 rounded animate-pulse" />
+//         ) : (
+//           <p className="text-sm font-bold text-center mb-2">{deal.brand}</p>
+//         )}
+
+//         <img
+//           src={`/images/deal-${index + 1}.png`}
+//           alt="deal"
+//           className="w-full h-20 object-cover rounded-md"
+//         />
+//       </div>
+
+//       {/* 오른쪽: 정보 */}
+//       <CardContent className="flex-1 pt-4 p-0">
+//         {showSkeleton ? (
+//           <>
+//             <div className="h-4 mb-2 bg-gray-200 rounded-sm animate-pulse w-3/4" />
+//             <div className="h-3 mb-2 bg-gray-100 rounded-sm animate-pulse w-full" />
+//             <div className="h-3 bg-gray-100 rounded-sm animate-pulse w-1/2" />
+//           </>
+//         ) : (
+//           <>
+//             <CardTitle className="text-base font-bold mb-1">{deal.title}</CardTitle>
+//             <CardDescription className="text-sm mb-2">{deal.description}</CardDescription>
+//             <span className="text-red-500 text-sm font-bold">{getDiscountLabel(deal)}</span>
+//           </>
+//         )}
+//       </CardContent>
+//     </Card>
+//   );
+// };
+
+// export default TopCouponCard;
+
 import { Card, CardContent, CardTitle, CardDescription } from '@/components/Card';
 import { TopCoupon } from '@/apis/coupon/getTopCoupons';
 
@@ -12,44 +73,43 @@ const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
   const showSkeleton = isLoading || !deal;
 
   return (
-    <Card className="relative flex flex-row items-start px-4 py-3 gap-4 shadow-md rounded-xl">
+    <Card className="relative w-[176px] flex flex-col items-center px-3 py-3 gap-3 shadow-md rounded-xl">
       {/* 순위 뱃지 */}
       <div
-        className={`absolute -top-3 -left-3 w-10 h-10 rounded-full text-white text-sm flex items-center justify-center font-bold shadow-md ${
+        className={`absolute -top-3 -left-3 w-8 h-8 rounded-full text-white text-xs flex items-center justify-center font-bold shadow-md ${
           index === 0 ? 'bg-red-500' : index === 1 ? 'bg-yellow-500' : 'bg-gray-500'
         }`}
       >
         {index + 1}위
       </div>
 
-      {/* 왼쪽: 브랜드명 + 이미지 */}
-      <div className="flex flex-col items-center w-28 pt-4">
-        {showSkeleton ? (
-          <div className="w-20 h-4 bg-gray-200 mb-2 rounded animate-pulse" />
-        ) : (
-          <p className="text-sm font-bold text-center mb-2">{deal.brand}</p>
-        )}
+      {/* 브랜드명 */}
+      {showSkeleton ? (
+        <div className="w-20 h-4 bg-gray-200 mb-1 rounded animate-pulse" />
+      ) : (
+        <p className="text-xs font-bold text-center">{deal.brand}</p>
+      )}
 
-        <img
-          src={`/images/deal-${index + 1}.png`}
-          alt="deal"
-          className="w-full h-20 object-cover rounded-md"
-        />
-      </div>
+      {/* 이미지 */}
+      <img
+        src={`/images/deal-${index + 1}.png`}
+        alt="deal"
+        className="w-full h-20 object-cover rounded-md"
+      />
 
-      {/* 오른쪽: 정보 */}
-      <CardContent className="flex-1 pt-4 p-0">
+      {/* 정보 */}
+      <CardContent className="flex flex-col items-start gap-1 p-0 w-full">
         {showSkeleton ? (
           <>
-            <div className="h-4 mb-2 bg-gray-200 rounded-sm animate-pulse w-3/4" />
-            <div className="h-3 mb-2 bg-gray-100 rounded-sm animate-pulse w-full" />
+            <div className="h-4 bg-gray-200 rounded-sm animate-pulse w-3/4" />
+            <div className="h-3 bg-gray-100 rounded-sm animate-pulse w-full" />
             <div className="h-3 bg-gray-100 rounded-sm animate-pulse w-1/2" />
           </>
         ) : (
           <>
-            <CardTitle className="text-base font-bold mb-1">{deal.title}</CardTitle>
-            <CardDescription className="text-sm mb-2">{deal.description}</CardDescription>
-            <span className="text-red-500 text-sm font-bold">{getDiscountLabel(deal)}</span>
+            <CardTitle className="text-sm font-semibold">{deal.title}</CardTitle>
+            <CardDescription className="text-xs line-clamp-2">{deal.description}</CardDescription>
+            <span className="text-red-500 text-xs font-bold">{getDiscountLabel(deal)}</span>
           </>
         )}
       </CardContent>
@@ -58,3 +118,18 @@ const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
 };
 
 export default TopCouponCard;
+
+// 내일 HotPlace.tsx 수정 – 카드 목록을 flex-row로
+{
+  /* <div className="flex flex-wrap gap-4 pt-4 justify-center">
+  {[0, 1, 2].map((index) => (
+    <TopCouponCard
+      key={index}
+      deal={bestDeals[index]}
+      index={index}
+      isLoading={isLoading}
+      getDiscountLabel={getDiscountLabel}
+    />
+  ))}
+</div> */
+}

--- a/src/components/TopCouponCard/TopCouponCard.tsx
+++ b/src/components/TopCouponCard/TopCouponCard.tsx
@@ -59,7 +59,7 @@
 
 // export default TopCouponCard;
 
-import { Card, CardContent, CardTitle, CardDescription } from '@/components/Card';
+import { Card, CardContent, CardTitle } from '@/components/Card';
 import { TopCoupon } from '@/apis/coupon/getTopCoupons';
 
 interface Props {
@@ -69,11 +69,11 @@ interface Props {
   getDiscountLabel: (deal: TopCoupon) => string;
 }
 
-const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
+const TopCouponCard = ({ deal, index, isLoading }: Props) => {
   const showSkeleton = isLoading || !deal;
 
   return (
-    <Card className="w-full max-w-[160px] flex flex-col items-center px-3 py-3 gap-2 shadow-md rounded-xl">
+    <Card className="relative w-full max-w-[160px] flex flex-col items-center px-3 py-3 gap-2 shadow-md rounded-xl">
       {/* 순위 뱃지 */}
       <div
         className={`absolute -top-3 -left-3 w-7 h-7 rounded-full text-white text-[10px] flex items-center justify-center font-bold shadow ${
@@ -87,7 +87,7 @@ const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
       {showSkeleton ? (
         <div className="w-20 h-4 bg-gray-200 mb-1 rounded animate-pulse" />
       ) : (
-        <p className="text-xs font-bold text-center">{deal.brand}</p>
+        <p className="text-xs font-bold text-center truncate max-w-full">{deal.brand}</p>
       )}
 
       {/* 이미지 */}
@@ -97,22 +97,17 @@ const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
         className="w-full h-20 object-cover rounded-md"
       />
 
-      {/* 정보 */}
-      <CardContent className="flex flex-col items-start gap-1 p-0 w-full">
+      {/* 제목만 노출 */}
+      <CardContent className="flex flex-col items-center p-0 w-full min-h-[40px]">
         {showSkeleton ? (
-          <>
-            <div className="h-4 bg-gray-200 rounded-sm animate-pulse w-3/4" />
-            <div className="h-3 bg-gray-100 rounded-sm animate-pulse w-full" />
-            <div className="h-3 bg-gray-100 rounded-sm animate-pulse w-1/2" />
-          </>
+          <div className="h-4 bg-gray-200 rounded-sm animate-pulse w-3/4" />
         ) : (
-          <>
-            <CardTitle className="text-sm font-semibold leading-snug">{deal.title}</CardTitle>
-            <CardDescription className="text-xs leading-tight line-clamp-2">
-              {deal.description}
-            </CardDescription>
-            <span className="text-red-500 text-xs font-bold">{getDiscountLabel(deal)}</span>
-          </>
+          <CardTitle
+            className="text-sm text-red-500 font-semibold text-center break-words line-clamp-2"
+            style={{ wordBreak: 'keep-all' }}
+          >
+            {deal.title}
+          </CardTitle>
         )}
       </CardContent>
     </Card>

--- a/src/components/TopCouponCard/TopCouponCard.tsx
+++ b/src/components/TopCouponCard/TopCouponCard.tsx
@@ -73,7 +73,7 @@ const TopCouponCard = ({ deal, index, isLoading, getDiscountLabel }: Props) => {
   const showSkeleton = isLoading || !deal;
 
   return (
-    <Card className="relative w-[160px] flex flex-col items-center px-3 py-3 gap-2 shadow-md rounded-xl">
+    <Card className="w-full max-w-[160px] flex flex-col items-center px-3 py-3 gap-2 shadow-md rounded-xl">
       {/* 순위 뱃지 */}
       <div
         className={`absolute -top-3 -left-3 w-7 h-7 rounded-full text-white text-[10px] flex items-center justify-center font-bold shadow ${

--- a/src/pages/hotplace/HotPlace.tsx
+++ b/src/pages/hotplace/HotPlace.tsx
@@ -109,7 +109,7 @@ const HotPlace = () => {
       {/* 인기 쿠폰 섹션 */}
       <div className="px-4">
         {/* 쿠폰 리스트 */}
-        <div className="flex flex-wrap gap-4 pt-4">
+        <div className="grid grid-cols-3 sm:grid-cols-3 xs:grid-cols-2 gap-4 justify-items-center pt-4">
           {[0, 1, 2].map((index) => (
             <TopCouponCard
               key={index}

--- a/src/pages/hotplace/HotPlace.tsx
+++ b/src/pages/hotplace/HotPlace.tsx
@@ -80,19 +80,12 @@ const HotPlace = () => {
   return (
     <div className="pb-20 space-y-4 min-h-full">
       {/* 헤더 섹션 - 마이페이지 스타일 적용 */}
-      <div className="px-4">
+      <div>
         <div className="flex items-start gap-2 mt-6 text-brand-darkblue">
-          <img
-            src={IMAGES.MOONER['mooner-hotplace']}
-            alt="문어 아이콘"
-            className="w-14 h-14 flex-shrink-0"
-          />
-          <div className="flex flex-col justify-center text-start">
-            <h2 className="text-base font-semibold leading-snug min-[375px]:text-xl min-[375px]:font-bold min-[375px]:leading-normal text-center">
-              <span className="block text-nowrap">요즘 뜨는 핫플레이스를 찾고,</span>
-              <span className="block text-nowrap">내 근처 쿠폰을 저장해보세요!</span>
-            </h2>
-          </div>
+          <h2 className="title-1 mt-6 flex items-center text-brand-darkblue gap-2">
+            <img src={IMAGES.MOONER['mooner-hotplace']} alt="문어 아이콘" className="w-15 h-15" />
+            요즘 뜨는 핫플레이스를 찾고, <br />내 근처 쿠폰을 저장해보세요!
+          </h2>
         </div>
 
         {/* MZ PICK 배너 */}

--- a/src/pages/hotplace/HotPlace.tsx
+++ b/src/pages/hotplace/HotPlace.tsx
@@ -81,10 +81,19 @@ const HotPlace = () => {
     <div className="pb-20 space-y-4 min-h-full">
       {/* 헤더 섹션 - 마이페이지 스타일 적용 */}
       <div className="px-4">
-        <h2 className="title-1 mt-6 flex items-center text-brand-darkblue gap-2">
-          <img src={IMAGES.MOONER['mooner-hotplace']} alt="문어 아이콘" className="w-15 h-15" />
-          요즘 뜨는 핫플레이스를 찾고, <br />내 근처 쿠폰을 저장해보세요!
-        </h2>
+        <div className="flex items-start gap-2 mt-6 text-brand-darkblue">
+          <img
+            src={IMAGES.MOONER['mooner-hotplace']}
+            alt="문어 아이콘"
+            className="w-14 h-14 flex-shrink-0"
+          />
+          <div className="flex flex-col justify-center text-start">
+            <h2 className="text-base font-semibold leading-snug min-[375px]:text-xl min-[375px]:font-bold min-[375px]:leading-normal text-center">
+              <span className="block text-nowrap">요즘 뜨는 핫플레이스를 찾고,</span>
+              <span className="block text-nowrap">내 근처 쿠폰을 저장해보세요!</span>
+            </h2>
+          </div>
+        </div>
 
         {/* MZ PICK 배너 */}
         <div className="mt-6 mb-4">

--- a/src/pages/hotplace/HotPlace.tsx
+++ b/src/pages/hotplace/HotPlace.tsx
@@ -83,19 +83,42 @@ const HotPlace = () => {
       <div className="px-4">
         <h2 className="title-1 mt-6 flex items-center text-brand-darkblue gap-2">
           <img src={IMAGES.MOONER['mooner-hotplace']} alt="문어 아이콘" className="w-15 h-15" />
-          요즘 뜨는핫플레이스를 찾고, <br />내 근처 쿠폰을 저장해보세요!
+          요즘 뜨는 핫플레이스를 찾고, <br />내 근처 쿠폰을 저장해보세요!
         </h2>
 
         {/* MZ PICK 배너 */}
         <div className="mt-6 mb-4">
           <Card className="bg-gradient-to-r from-brand-yellow to-brand-red text-white">
-            <CardContent className="text-center py-2">
-              <div className="flex items-center justify-center gap-2">
-                <TrendingUp className="w-5 h-5" />
-                <span className="font-bold">요즘 핫한 MZ들의 PICK은?!</span>
+            <CardContent className="py-2 px-3">
+              <div className="flex flex-col items-center justify-center text-center gap-1">
+                {/* 아이콘 + 제목 가로 정렬 */}
+                <div className="flex items-center justify-center gap-1">
+                  <TrendingUp className="w-5 h-5" />
+                  <span className="font-bold">요즘 핫한 MZ들의 PICK은?!</span>
+                </div>
+                {/* 설명 문구 */}
+                {/* <span className="font-semibold text-sm">
+                  지금 Top3 쿠폰을 확인하고 지도에서 주변 매장을 찾아보세요 !
+                </span> */}
               </div>
             </CardContent>
           </Card>
+        </div>
+      </div>
+
+      {/* 인기 쿠폰 섹션 */}
+      <div className="px-4">
+        {/* 쿠폰 리스트 */}
+        <div className="flex flex-wrap gap-4 pt-4">
+          {[0, 1, 2].map((index) => (
+            <TopCouponCard
+              key={index}
+              deal={bestDeals[index]}
+              index={index}
+              isLoading={isLoading}
+              getDiscountLabel={getDiscountLabel}
+            />
+          ))}
         </div>
       </div>
 
@@ -156,26 +179,6 @@ const HotPlace = () => {
             )}
           </CardContent>
         </Card>
-      </div>
-
-      {/* 인기 쿠폰 섹션 */}
-      <div className="px-4">
-        <h1 className="text-xl font-bold text-brand-darkblue mb-4">
-          인기 쿠폰 <span className="text-red-400 font-bold">TOP 3</span>
-        </h1>
-
-        {/* 쿠폰 리스트 */}
-        <div className="flex flex-col gap-4 pt-4">
-          {[0, 1, 2].map((index) => (
-            <TopCouponCard
-              key={index}
-              deal={bestDeals[index]}
-              index={index}
-              isLoading={isLoading}
-              getDiscountLabel={getDiscountLabel}
-            />
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/src/pages/mission/Mission.tsx
+++ b/src/pages/mission/Mission.tsx
@@ -28,7 +28,7 @@ const MissionPage = () => {
     }
   }, [scrollTo]);
   return (
-    <div className="p-4 pt-1">
+    <div>
       <FlatTabs tabs={TABS} value={selectedTab} onChange={setSelectedTab} />
 
       <div className="mt-6">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,7 +32,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/line-clamp')],
 };
 
 export default config;


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #198

### 🔎 작업 내용

- [x] TopCouponCard UI  수정
- [x] TopCouponCard 위치 헤더 아래로 위치하도록 수정
- [x] TopCouponCard 구성 요소, 브랜드명, 이미지, 쿠폰타이틀 3개로 축소
- [x] 핫플 페이지 해더 패딩 삭제
- [x] 미션 페이지 전체 패딩 삭제

### 📸 스크린샷
**쿠폰카드 flex에서 grid로 적용**
![image](https://github.com/user-attachments/assets/9f153ee0-5451-47fc-920f-b7bc933716b1)


### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
